### PR TITLE
Changed sample point range for 2D manifold visualization

### DIFF
--- a/docs/articles/examples/variational_autoencoder.R
+++ b/docs/articles/examples/variational_autoencoder.R
@@ -100,9 +100,9 @@ x_test_encoded %>%
 n <- 15  # figure with 15x15 digits
 digit_size <- 28
 
-# we will sample n points within [-15, 15] standard deviations
-grid_x <- seq(-15, 15, length.out = n)
-grid_y <- seq(-15, 15, length.out = n)
+# we will sample n points within [-4, 4] standard deviations
+grid_x <- seq(-4, 4, length.out = n)
+grid_y <- seq(-4, 4, length.out = n)
 
 rows <- NULL
 for(i in 1:length(grid_x)){

--- a/vignettes/examples/variational_autoencoder.R
+++ b/vignettes/examples/variational_autoencoder.R
@@ -100,9 +100,9 @@ x_test_encoded %>%
 n <- 15  # figure with 15x15 digits
 digit_size <- 28
 
-# we will sample n points within [-15, 15] standard deviations
-grid_x <- seq(-15, 15, length.out = n)
-grid_y <- seq(-15, 15, length.out = n)
+# we will sample n points within [-4, 4] standard deviations
+grid_x <- seq(-4, 4, length.out = n)
+grid_y <- seq(-4, 4, length.out = n)
 
 rows <- NULL
 for(i in 1:length(grid_x)){


### PR DESCRIPTION
Changed the range for the 2D manifold visualization from +/- 15 standard deviations to +/- 4 standard deviations, because it gives a better representation of the manifold space.  It is possible to see all the numbers and the transitions between them in the space.   I posted examples of the difference in the visualizations - here: https://github.com/rstudio/keras/issues/48#issuecomment-310877166
