### PR TITLE
Fixed y-range issue (#54), and added ggplot method.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     methods,
     R6
 Suggests: 
+    ggplot2,
     testthat, 
     knitr
 Remotes:

--- a/R/history.R
+++ b/R/history.R
@@ -113,9 +113,9 @@ plot.keras_training_history <- function(x, y, metrics = NULL, method = c("auto",
         df2[df2$data == 'training', 'value'][1] > df2[df2$data == 'training', 'value'][x$params$epochs],
         "topright", "bottomright")
       if (x$params$do_validation)
-        legend(legend_location, legend = c(metric, paste0("val_", metric)), pch = c(1, 4))
+        graphics::legend(legend_location, legend = c(metric, paste0("val_", metric)), pch = c(1, 4))
       else
-        legend(legend_location, legend = metric, pch = 1)
+        graphics::legend(legend_location, legend = metric, pch = 1)
     }
   }
 }


### PR DESCRIPTION
This PR contains a version of the `plot.keras_training_history` function. There is two main changes: there is now a `ggplot2` method, and the base method now takes validation metrics into account when calculating the y-range.

The code for the base plot has changed a bit, partly to fix the bug and partly to factor out common tasks between the two methods.

I have added `ggplot2` to Suggests.

## Plot examples

```
data(iris)

m <- keras_model_sequential() %>%
  layer_dense(12, input_shape = 4) %>%
  layer_dense(4, activation = 'sigmoid') %>%
  compile('adam', 'categorical_crossentropy', 'accuracy')

m2 <- m

h <- fit(m, as.matrix(iris[1:4]), to_categorical(iris[[5]]), 8, 100, validation_split = 0.2)

h2 <- fit(m2, as.matrix(iris[1:4]), to_categorical(iris[[5]]), 8, 50)
```

History `h` has validation data, `h2` does not.

Previously, the y range could get cause the validation to (partially) not be plotted, such as here:

`old_plot(h)`

![old](https://user-images.githubusercontent.com/15309336/27730781-d8f4601a-5d8a-11e7-8f23-ef94edae23dc.png)

This behavior is now fixed:

`plot(h, method = "base")`

![base_new](https://user-images.githubusercontent.com/15309336/27730840-06ca0d14-5d8b-11e7-8080-ad00947791fd.png)

The function now also checks whether `ggplot2` is available, and when it is, uses that package instead. 

For my system, these are equivalent and give the plot below:

```
plot(h)
plot(h, method = "auto")
plot(h, method = "ggplot2")
```

![ggplot_val](https://user-images.githubusercontent.com/15309336/27730915-4e80cd6e-5d8b-11e7-98c2-2d48e49a7b65.png)

When no validation data was used, the plots look like this:

`plot(h2, method = "base") # is exactly equivalent to the old behavior`

![base_no_val](https://user-images.githubusercontent.com/15309336/27730964-84ce2876-5d8b-11e7-84e1-f99825bb1e7a.png)

`plot(h2, method = "ggplot2")`

![ggplot_no_val](https://user-images.githubusercontent.com/15309336/27731038-cb4c9fb2-5d8b-11e7-8bb5-33e384e86c98.png)

