### PR TITLE
force loading of TensorFlow on startup

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -26,6 +26,10 @@ keras <- NULL
      
     on_load = function() {
       check_implementation_version()
+      
+      # force loading of TensorFlow (needed for S3
+      # dispatch of methods on Tensors)
+      tensorflow::tf$VERSION
     },
     
     on_error = function(e) {


### PR DESCRIPTION
This PR should resolve issues of the form described in https://github.com/rstudio/keras/issues/108.

The underlying issue: when the `tensorflow` package is loaded, the `tf` module is only lazy-loaded, with the intention of later loading it when accessed through e.g. `tf$`. However, the `-` method defined by the `tensorflow` package doesn't attempt to load the `tf` module before dispatching; e.g.

```R
> tensorflow:::`-.tensorflow.python.framework.ops.Tensor`
function(a, b) {
  if (missing(b)) {
    if (py_has_attr(tf, "negative"))
      tf$negative(a)
    else
      tf$neg(a)
  } else {
    if (py_has_attr(tf, "subtract"))
      tf$subtract(a, b)
    else
      tf$sub(a, b)
  }
}
```

Because the checks are guarded by `py_has_attr()`, and that function doesn't force loading of `tf`, we fail to resolve the attributes (methods) in the `tf` module.

This might also be better resolved in the `reticulate` package, by forcing `py_has_attr()` to load a lazy-loaded module.

@jjallaire, let me know what you think.