### PR TITLE
Fix error when plotting training history after early stopping.

### DIFF
--- a/R/history.R
+++ b/R/history.R
@@ -137,16 +137,24 @@ plot.keras_training_history <- function(x, y, metrics = NULL, method = c("auto",
 
 #' @export
 as.data.frame.keras_training_history <- function(x, ...) {
+  # pad to epochs if necessary
+  values <- x$metrics
+  pad <- x$params$epochs - length(values$loss)
+  pad_data <- list()
+  for (metric in x$params$metrics)
+    pad_data[[metric]] <- rep_len(NA, pad)
+  values <- rbind(values, pad_data)
+
   # prepare data to plot as a data.frame
   df <- data.frame(
     epoch = seq_len(x$params$epochs),
-    value = unlist(x$metrics),
+    value = unlist(values),
     metric = rep(sub("^val_", "", names(x$metrics)), each = x$params$epochs),
     data = rep(grepl("^val_", names(x$metrics)), each = x$params$epochs)
   )
   rownames(df) <- NULL
   
-  # order factor levles appropriately
+  # order factor levels appropriately
   df$data <- factor(df$data, c(FALSE, TRUE), c('training', 'validation'))
   df$metric <- factor(df$metric, unique(sub("^val_", "", names(x$metrics))))
 


### PR DESCRIPTION
This PR resolves issue [#117](https://github.com/rstudio/keras/issues/117#issuecomment-326672778). The issue being that plotting of training history would fail when early stopping was used. 

The fix was to pad the training metrics with NAs so that the number of rows is the same as the specified number of training epochs, not the number that occurred before early stopping.

Now when plotting the training history after early stopping we get a plot like this:
![early_stopping_plot](https://user-images.githubusercontent.com/4865998/30023371-527f437e-916f-11e7-8e80-4de37afac207.png)

There are few things I am a little unsure of:

1. The fix uses NAs which causes the following warning messages to be displayed when calling the `plot()` function:
```
Warning messages:
1: Removed 352 rows containing non-finite values (stat_smooth). 
2: Removed 352 rows containing missing values (geom_point). 
```
Should we hide these or are we happy to have the user see them?

2. Should I add a test case for this issue so that it isn't accidentally broken again in the future?

3. Speaking of tests, I did run the `test_check`, however, both before and after my changes I am getting this output:

```
OK: 209 SKIPPED: 2 FAILED: 0
```
I am assuming that the two skipped tests are due to me only using the TF backend and not CNTK or Theano? Please let me know if this is something I need to have a closer look at.

4. In order to figure out how much padding to add, I used the length of `x$metrics$loss`. My thinking was that there should always be a "loss" in "metrics", so it would be safe to do this - is that a reasonable assumption? 


Let me know what you think and if there are any other changes I need to make.

James
