### PR TITLE
change nueral style transfer indexes to 1-based

### DIFF
--- a/vignettes/examples/neural_style_transfer.R
+++ b/vignettes/examples/neural_style_transfer.R
@@ -141,9 +141,9 @@ content_loss <- function(base, combination){
 # designed to keep the generated image locally coherent
 
 total_variation_loss <- function(x){
-  y_ij  <- x[,0:(img_nrows - 2L), 0:(img_ncols - 2L),]
-  y_i1j <- x[,1:(img_nrows - 1L), 0:(img_ncols - 2L),]
-  y_ij1 <- x[,0:(img_nrows - 2L), 1:(img_ncols - 1L),]
+  y_ij  <- x[,1:(img_nrows - 1L), 1:(img_ncols - 1L),]
+  y_i1j <- x[,2:(img_nrows), 1:(img_ncols - 1L),]
+  y_ij1 <- x[,1:(img_nrows - 1L), 2:(img_ncols),]
   
   a <- K$square(y_ij - y_i1j)
   b <- K$square(y_ij - y_ij1)
@@ -153,8 +153,8 @@ total_variation_loss <- function(x){
 # combine these loss functions into a single scalar
 loss <- K$variable(0.0)
 layer_features <- output_dict$block4_conv2
-base_image_features <- layer_features[0,,,]
-combination_features <- layer_features[2,,,]
+base_image_features <- layer_features[1,,,]
+combination_features <- layer_features[3,,,]
 
 loss <- loss + content_weight*content_loss(base_image_features, 
                                            combination_features)
@@ -165,8 +165,8 @@ feature_layers = c('block1_conv1', 'block2_conv1',
 
 for(layer_name in feature_layers){
   layer_features <- output_dict[[layer_name]]
-  style_reference_features <- layer_features[1,,,]
-  combination_features <- layer_features[2,,,]
+  style_reference_features <- layer_features[2,,,]
+  combination_features <- layer_features[3,,,]
   sl <- style_loss(style_reference_features, combination_features)
   loss <- loss + ((style_weight / length(feature_layers)) * sl)
 }

--- a/vignettes/examples/variational_autoencoder.R
+++ b/vignettes/examples/variational_autoencoder.R
@@ -21,8 +21,8 @@ z_mean <- layer_dense(h, latent_dim)
 z_log_var <- layer_dense(h, latent_dim)
 
 sampling <- function(arg){
-  z_mean <- arg[,0:1]
-  z_log_var <- arg[,2:3]
+  z_mean <- arg[,1:2]
+  z_log_var <- arg[,3:4]
   
   epsilon <- K$random_normal(
     shape = c(K$shape(z_mean)[[1]]), 

--- a/vignettes/examples/variational_autoencoder_deconv.R
+++ b/vignettes/examples/variational_autoencoder_deconv.R
@@ -77,8 +77,8 @@ z_mean <- layer_dense(hidden, units = latent_dim)
 z_log_var <- layer_dense(hidden, units = latent_dim)
 
 sampling <- function(args) {
-  z_mean <- args[, 0:(latent_dim - 1)]
-  z_log_var <- args[, latent_dim:(2 * latent_dim - 1)]
+  z_mean <- args[, 1:(latent_dim)]
+  z_log_var <- args[, (latent_dim + 1):(2 * latent_dim)]
   
   epsilon <- K$random_normal(
     shape = c(K$shape(z_mean)[[1]]),


### PR DESCRIPTION
@dfalbel I attempted here to modify the neural style example to use 1-based indexing. However, when I source the script I get this error:

```
 Error in py_call_impl(callable, dots$args, dots$keywords) : 
  ValueError: cannot reshape array of size 1366800 into shape (1,) 
20. stop(structure(list(message = "ValueError: cannot reshape array of size 1366800 into shape (1,)", 
    call = py_call_impl(callable, dots$args, dots$keywords), 
    cppstack = structure(list(file = "", line = -1L, stack = c("1   reticulate.so                       0x000000010b5f82a4 _ZN4Rcpp9exceptionC2EPKcb + 276", 
    "2   reticulate.so                       0x000000010b5f80d0 _ZN4Rcpp4stopERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE + 48",  ... 
19. _wrapfunc at fromnumeric.py#57
18. reshape at fromnumeric.py#232
17. np$reshape(x, as.integer(dim), order) at array.R#86
16. array_reshape(., c(1, dim(img))) 
15. function_list[[k]](value) 
14. withVisible(function_list[[k]](value)) 
13. freduce(value, `_function_list`) 
12. `_fseq`(`_lhs`) 
11. eval(quote(`_fseq`(`_lhs`)), env, env) 
10. eval(quote(`_fseq`(`_lhs`)), env, env) 
9. withVisible(eval(quote(`_fseq`(`_lhs`)), env, env)) 
8. image_load(path, target_size = c(img_nrows, img_ncols)) %>% image_to_array() %>% 
    array_reshape(c(1, dim(img))) at neural_style_transfer.R#59
7. preprocess_image(base_image_path) at python.R#1129
6. py_resolve_dots(list(...)) at python.R#1111
5. K$variable(preprocess_image(base_image_path)) at neural_style_transfer.R#82
4. eval(ei, envir) 
3. eval(ei, envir) 
2. withVisible(eval(ei, envir)) 
1. source("~/packages/keras/vignettes/examples/neural_style_transfer.R", 
    echo = TRUE) 
```

However, I also get that same error on master!

Could you review this PR and if you have time also possibly create a patch to overcome the error condition?
