### PR TITLE
Enable predictions in cloudml from savedmodels

### DIFF
--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -280,7 +280,8 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
     signature_def_map = list(
       serving_default = tensorflow::tf$saved_model$signature_def_utils$build_signature_def(
         inputs = input_info,
-        outputs = output_info
+        outputs = output_info,
+        method_name = tensorflow::tf$saved_model$signature_constants$PREDICT_METHOD_NAME
       )
     )
   )


### PR DESCRIPTION
`cloudml` seems to expect the signature `method_name` to be set. Otherwise, once the keras model is exported using `export_savedmodel()` and uploaded to cloudml using `cloudml::cloudml_deploy()`, predictions in `cloudml` using `cloudml::cloudml_predict()` fails with error:

```
Error in cloudml::cloudml_predict(list(list(input = array(0, c(32, 32,  : 
  Prediction failed: Error during model execution: AbortionError(code=StatusCode.INTERNAL, details="Expected prediction signature method_name to be one of {tensorflow/serving/predict, tensorflow/serving/classify, tensorflow/serving/regress}. Was: ")
```