### PR TITLE
Remove workaround for export_savedmodel fixed in tf 1.4.1

### DIFF
--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -228,19 +228,6 @@ unserialize_model <- function(model, custom_objects = NULL, compile = TRUE) {
   load_model_hdf5(tmp, custom_objects = custom_objects, compile = compile)
 }
 
-model_to_tensors_info <- function(layers, name) {
-  named_layers <- lapply(layers, function(layer) {
-    tensorflow::tf$saved_model$utils$build_tensor_info(layer[[name]])
-  })
-  
-  if (length(named_layers) == 1)
-    names(named_layers) <- name
-  else
-    names(named_layers) <- paste(name, seq_along(named_layers), sep = "")
-  
-  named_layers
-}
-
 #' Export a Saved Model
 #'
 #' Serialize a model to disk.
@@ -259,12 +246,14 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
   
   sess <- backend()$get_session()
   
-  input_tensor <- object$input_layers
-  output_tensor <- object$output_layers
+  input_info <- list(
+    input = tensorflow::tf$saved_model$utils$build_tensor_info(object$input)
+  )
 
-  input_info <- model_to_tensors_info(input_tensor, "input")
-  output_info <- model_to_tensors_info(output_tensor, "output")
-  
+  output_info <- list(
+    output = tensorflow::tf$saved_model$utils$build_tensor_info(object$output)
+  )
+
   builder <- tensorflow::tf$saved_model$builder$SavedModelBuilder(export_dir_base)
   builder$add_meta_graph_and_variables(
     sess,

--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -259,14 +259,8 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
   
   sess <- backend()$get_session()
   
-  if (tensorflow::tf_version() < '1.4') {
-    input_tensor <- object$input_layers
-    output_tensor <- object$output_layers
-  }
-  else {
-    input_tensor <- object$layers
-    output_tensor <- object$layers
-  }
+  input_tensor <- object$input_layers
+  output_tensor <- object$output_layers
 
   input_info <- model_to_tensors_info(input_tensor, "input")
   output_info <- model_to_tensors_info(output_tensor, "output")


### PR DESCRIPTION
While testing `export_savedmodel()` under TensorFlow 1.4.0, a special case was introduced; however, in 1.4.1 this behavior seems reverted and the special case introduced in 1.4.0 is no longer necessary since it exports models incorrectly. Also, under the tensorflow-keras implementation, not all fields were available using the same identifiers.