### PR TITLE
export_savedmodel() to support multiple inputs and outputs

### DIFF
--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -245,27 +245,17 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
     stop("'export_savedmodel' is only supported in the TensorFlow backend.")
   
   sess <- backend()$get_session()
-  
-  input_list <- object$input
-  if (!is.list(object$input)) {
-    input_list <- list(object$input)
-  }
-  
-  input_info <- lapply(input_list, function(e) {
-    tensorflow::tf$saved_model$utils$build_tensor_info(e)
-  })
-  
-  output_list <- object$output
-  if (!is.list(object$output)) {
-    output_list <- list(object$output)
-  }
 
-  output_info <- lapply(output_list, function(e) {
-    tensorflow::tf$saved_model$utils$build_tensor_info(e)
+  input_info <- lapply(object$input_layers, function(e) {
+    tensorflow::tf$saved_model$utils$build_tensor_info(e$input)
   })
   
-  names(input_info) <- lapply(input_info, function(e) strsplit(e$name, "_")[[1]][[1]])
-  names(output_info) <- lapply(output_info, function(e) strsplit(e$name, "_")[[1]][[1]])
+  output_info <- lapply(object$output_layers, function(e) {
+    tensorflow::tf$saved_model$utils$build_tensor_info(e$output)
+  })
+  
+  names(input_info) <- lapply(object$input_layers, function(e) e$name)
+  names(output_info) <- lapply(object$output_layers, function(e) e$name)
 
   builder <- tensorflow::tf$saved_model$builder$SavedModelBuilder(export_dir_base)
   builder$add_meta_graph_and_variables(

--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -246,16 +246,16 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
   
   sess <- backend()$get_session()
 
-  input_info <- lapply(object$input_layers, function(e) {
-    tensorflow::tf$saved_model$utils$build_tensor_info(e$input)
+  input_info <- lapply(object$inputs, function(e) {
+    tensorflow::tf$saved_model$utils$build_tensor_info(e)
   })
   
-  output_info <- lapply(object$output_layers, function(e) {
-    tensorflow::tf$saved_model$utils$build_tensor_info(e$output)
+  output_info <- lapply(object$outputs, function(e) {
+    tensorflow::tf$saved_model$utils$build_tensor_info(e)
   })
   
-  names(input_info) <- lapply(object$input_layers, function(e) e$name)
-  names(output_info) <- lapply(object$output_layers, function(e) e$name)
+  names(input_info) <- lapply(object$input_names, function(e) e)
+  names(output_info) <- lapply(object$output_names, function(e) e)
 
   builder <- tensorflow::tf$saved_model$builder$SavedModelBuilder(export_dir_base)
   builder$add_meta_graph_and_variables(

--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -246,13 +246,26 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
   
   sess <- backend()$get_session()
   
-  input_info <- list(
-    input = tensorflow::tf$saved_model$utils$build_tensor_info(object$input)
-  )
+  input_list <- object$input
+  if (!is.list(object$input)) {
+    input_list <- list(object$input)
+  }
+  
+  input_info <- lapply(input_list, function(e) {
+    tensorflow::tf$saved_model$utils$build_tensor_info(e)
+  })
+  
+  output_list <- object$output
+  if (!is.list(object$output)) {
+    output_list <- list(object$output)
+  }
 
-  output_info <- list(
-    output = tensorflow::tf$saved_model$utils$build_tensor_info(object$output)
-  )
+  output_info <- lapply(output_list, function(e) {
+    tensorflow::tf$saved_model$utils$build_tensor_info(e)
+  })
+  
+  names(input_info) <- lapply(input_info, function(e) strsplit(e$name, "_")[[1]][[1]])
+  names(output_info) <- lapply(output_info, function(e) strsplit(e$name, "_")[[1]][[1]])
 
   builder <- tensorflow::tf$saved_model$builder$SavedModelBuilder(export_dir_base)
   builder$add_meta_graph_and_variables(


### PR DESCRIPTION
Found models (like [/models/keras-multiples.R](https://github.com/rstudio/tfdeploy/blob/master/tests/testthat/models/keras-multiples.R)) where `export_savedmodel()` was not producing the right naming.