### PR TITLE
Added latent_dim to sampling function on variational_autoencoder example

### DIFF
--- a/vignettes/examples/variational_autoencoder.R
+++ b/vignettes/examples/variational_autoencoder.R
@@ -21,8 +21,8 @@ z_mean <- layer_dense(h, latent_dim)
 z_log_var <- layer_dense(h, latent_dim)
 
 sampling <- function(arg){
-  z_mean <- arg[,1:2]
-  z_log_var <- arg[,3:4]
+  z_mean <- arg[, 1:(latent_dim)]
+  z_log_var <- arg[, (latent_dim + 1):(2 * latent_dim)]
   
   epsilon <- k_random_normal(
     shape = c(k_shape(z_mean)[[1]]), 


### PR DESCRIPTION
This change always the sampling function to work correctly for latent dimensions other than 2.  This also matches the code for the variational_autoencoder_deconv.