### PR TITLE
Support learning phases in `export_savedmodel()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,10 @@
 
 Install the development version with: `install_github("rstudio/keras")`
 
-- Ensure that models saved via export_savedmodel can be served from CloudML
+- Models saved via `export_savedmodel()` that make use of learning phases can
+  now be exported without having to manually reload the original model.
+
+- Ensure that models saved via `export_savedmodel()` can be served from CloudML
 
 - Run image data generators with R preprocessing functions on the main thread
 

--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -262,10 +262,7 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
     stop("'export_savedmodel' is only supported in the TensorFlow backend.")
 
   if (!is_tensorflow_implementation()) {
-    original_learning_phase <- k_learning_phase()
-    on.exit(function() k_set_learning_phase(original_learning_phase), add = TRUE)
-    
-    k_set_learning_phase(FALSE)
+    k_set_learning_phase(0)
     object <- reload_model(object)
   }
   

--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -230,7 +230,7 @@ unserialize_model <- function(model, custom_objects = NULL, compile = TRUE) {
 
 reload_model <- function(object) {
   old_config <- object$get_config()
-  old_weigths <- object$get_weights()
+  old_weights <- object$get_weights()
   
   models <- import("keras.models")
   if ("keras.models.Sequential" %in% class(object)) {
@@ -240,7 +240,7 @@ reload_model <- function(object) {
     new_model <- models$Model$from_config(old_config)
   }
   
-  new_model$set_weights(old_weigths)
+  new_model$set_weights(old_weights)
   
   new_model
 }
@@ -261,6 +261,9 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
   if (!is_backend("tensorflow"))
     stop("'export_savedmodel' is only supported in the TensorFlow backend.")
 
+  learning_phase <- k_learning_phase()
+  on.exit(k_set_learning_phase(learning_phase))
+  
   k_set_learning_phase(FALSE)
   object <- reload_model(object)
   

--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -228,6 +228,23 @@ unserialize_model <- function(model, custom_objects = NULL, compile = TRUE) {
   load_model_hdf5(tmp, custom_objects = custom_objects, compile = compile)
 }
 
+reload_model <- function(object) {
+  old_config <- object$get_config()
+  old_weigths <- object$get_weights()
+  
+  models <- import("keras.models")
+  if ("keras.models.Sequential" %in% class(object)) {
+    new_model <- models$Sequential$from_config(old_config)
+  }
+  else {
+    new_model <- models$Model$from_config(old_config)
+  }
+  
+  new_model$set_weights(old_weigths)
+  
+  new_model
+}
+
 #' Export a Saved Model
 #'
 #' Serialize a model to disk.
@@ -243,6 +260,9 @@ unserialize_model <- function(model, custom_objects = NULL, compile = TRUE) {
 export_savedmodel.keras.engine.training.Model <- function(object, export_dir_base, ...) {
   if (!is_backend("tensorflow"))
     stop("'export_savedmodel' is only supported in the TensorFlow backend.")
+
+  k_set_learning_phase(FALSE)
+  object <- reload_model(object)
   
   sess <- backend()$get_session()
 

--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -262,8 +262,8 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
     stop("'export_savedmodel' is only supported in the TensorFlow backend.")
 
   if (!is_tensorflow_implementation()) {
-    learning_phase <- k_learning_phase()
-    on.exit(k_set_learning_phase(learning_phase))
+    original_learning_phase <- k_learning_phase()
+    on.exit(function() k_set_learning_phase(original_learning_phase), add = TRUE)
     
     k_set_learning_phase(FALSE)
     object <- reload_model(object)

--- a/R/model-persistence.R
+++ b/R/model-persistence.R
@@ -261,11 +261,13 @@ export_savedmodel.keras.engine.training.Model <- function(object, export_dir_bas
   if (!is_backend("tensorflow"))
     stop("'export_savedmodel' is only supported in the TensorFlow backend.")
 
-  learning_phase <- k_learning_phase()
-  on.exit(k_set_learning_phase(learning_phase))
-  
-  k_set_learning_phase(FALSE)
-  object <- reload_model(object)
+  if (!is_tensorflow_implementation()) {
+    learning_phase <- k_learning_phase()
+    on.exit(k_set_learning_phase(learning_phase))
+    
+    k_set_learning_phase(FALSE)
+    object <- reload_model(object)
+  }
   
   sess <- backend()$get_session()
 


### PR DESCRIPTION
Run `https://github.com/rstudio/cloudml/blob/master/inst/examples/keras/mnist_mlp.R`, then run:

```r
export_savedmodel(model, "savedmodel")
```

The export succeeds but contains a `learning_phase` placeholder, this PR follows the suggestion on https://blog.keras.io/keras-as-a-simplified-interface-to-tensorflow-tutorial.html to set `learning_phase(0)` and reload the model before exporting.