### PR TITLE
Fixes typos in two functions

### DIFF
--- a/R/layers-dropout.R
+++ b/R/layers-dropout.R
@@ -12,7 +12,7 @@
 #'   inputs have shape `(batch_size, timesteps, features)` and you want the
 #'   dropout mask to be the same for all timesteps, you can use
 #'   `noise_shape=c(batch_size, 1, features)`.
-#' @param seed A Python integer to use as random seed.
+#' @param seed integer to use as random seed.
 #'
 #' @family core layers
 #' @family dropout layers   

--- a/R/layers-recurrent.R
+++ b/R/layers-recurrent.R
@@ -214,8 +214,7 @@ layer_cudnn_gru <- function(object, units,
 
 #' Long-Short Term Memory unit - Hochreiter 1997.
 #' 
-#' For a step-by-step description of the algorithm, see [this
-#' tutorial](http://deeplearning.net/tutorial/lstm.html).
+#' For a step-by-step description of the algorithm, see [this tutorial](http://deeplearning.net/tutorial/lstm.html).
 #' 
 #' @inheritParams layer_gru
 #' 


### PR DESCRIPTION
* Inserts space in layer_lstm roxygen notes.
* Removes word python from layer_dropout.