### PR TITLE
tile uses an integer vector not a list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ Install the development version with: `install_github("rstudio/keras")`
 
 - Fix issue with serializing models that have constraint arguments
 
+- Fix issue with `k_tile` that needs an integer vector instead of a list as the `n` argument.
+
 
 ## Keras 2.1.6 (CRAN)
 

--- a/R/backend.R
+++ b/R/backend.R
@@ -2814,7 +2814,7 @@ k_temporal_padding <- function(x, padding = c(1, 1)) {
 k_tile <- function(x, n) {
   keras$backend$tile(
     x = x,
-    n = list(as.integer(n))
+    n = as.integer(n)
   )
 }
 


### PR DESCRIPTION
I am not sure why but the following doesn't work:

```
p <- k_placeholder(shape = shape(NULL, 1, 1, NULL, 8))
k_tile(p, c(1, 1, 10, 1, 1))
 Error in py_call_impl(callable, dots$args, dots$keywords) : 
  ValueError: Shape must be rank 1 but is rank 2 for 'Tile_3' (op: 'Tile') with input shapes: [?,1,1,?,8], [1,5].
``` 

And this works (ie. removing the call for `list`):

```
K$tile(x = p, n = as.integer(c(1, 1, 10, 1, 1)))
Tensor("Tile_5:0", shape=(?, 1, 10, ?, 8), dtype=float32)
```
