### PR TITLE
Fixes typo in an argument description

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -788,7 +788,7 @@ flow_images_from_data <- function(
 #'   of the subdirectories directory tree will be included in the generator.
 #'   See [this script](https://gist.github.com/fchollet/0830affa1f7f19fd47b06d4cf89ed44d)
 #'   for more details.
-#' @param target_size integer vectir, default: `c(256, 256)`. The dimensions to
+#' @param target_size integer vector, default: `c(256, 256)`. The dimensions to
 #'   which all images found will be resized.
 #' @param color_mode one of "grayscale", "rbg". Default: "rgb". Whether the
 #'   images will be converted to have 1 or 3 color channels.


### PR DESCRIPTION
- Fix typo in the `target_size` description.

Closes  #469