### PR TITLE
add eager guide

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -242,6 +242,8 @@ To learn more about Keras, you can check out these articles:
 
 - [Using Pre-Trained Models](articles/applications.html)
 
+- [Keras with Eager Execution](articles/eager_guide.html)
+
 The [examples](articles/examples/index.html) demonstrate more advanced models including transfer learning, variational auto-encoding, question-answering with memory networks, text generation with stacked LSTMs, etc.
 
 The [function reference](reference/index.html) includes detailed information on all of the functions available in the package.

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -48,6 +48,8 @@ navbar:
           href: articles/why_use_keras.html
         - text: "--------------------------"
         - text: "Advanced"
+        - text: "Eager Execution"
+          href: articles/eager_guide.html
         - text: "Training Callbacks"
           href: articles/training_callbacks.html
         - text: "Keras Backend"

--- a/vignettes/eager_guide.Rmd
+++ b/vignettes/eager_guide.Rmd
@@ -12,7 +12,7 @@ menu:
     name: "Keras with eager execution"
     identifier: "keras-eager"
     parent: "keras-using-keras"
-    weight: 10
+    weight: 15
     
 ---
 
@@ -98,11 +98,17 @@ model <- iris_regression_model()
 ```
 
 At this point, the shapes of the model's weights are still unknown (note how no `input_shape` has been defined for its first layer).
-You can, however, already call the model on some test data:
+You can, however, already call the model on some dummy data:
 
 ```{r}
 model(k_constant(matrix(1:6, nrow = 2, ncol = 3)))
 ```
+
+```
+tf.Tensor(
+[[-1.1474639]
+ [-1.0472134]], shape=(2, 1), dtype=float32)
+ ```
 
 After that call, you can inspect the model's weights using 
 
@@ -114,14 +120,11 @@ This will not just display the tensor shapes, but the actual weight values.
 
 ## Losses and optimizers
 
-
-> JJA: We should explain why we need to use the tf loss and optimizer here
-
 An appropriate loss function for a regression task like this is mean squared error:
 
 ```{r}
 mse_loss <- function(y_true, y_pred, x) {
-  # can't use Keras loss_mean_squared_error() here
+  # it's required to use a TensorFlow function here, not loss_mean_squared_error() from Keras
   mse <- tf$losses$mean_squared_error(y_true, y_pred)
   # here you could compute and add other losses 
   mse
@@ -131,7 +134,7 @@ mse_loss <- function(y_true, y_pred, x) {
 Note how we have to use loss functions from TensorFlow, not the Keras equivalents. In the same vein, we need to use an optimizer from the `tf$train` module.
 
 ```{r}
-# can't use Keras' optimizer_adam()
+# have to use an optimizer from tf$train, not Keras
 optimizer <- tf$train$AdamOptimizer()
 ```
 
@@ -182,8 +185,33 @@ Datasets are available in non-eager (graph) execution as well. However, in eager
 batch
 ```
 
-> JJA: show output for simple data inspection (another case up above)
+```
+[[1]]
+tf.Tensor(
+[[1.4 5.1 0.2]
+ [1.4 4.9 0.2]
+ [1.3 4.7 0.2]
+ [1.5 4.6 0.2]
+ [1.4 5.  0.2]
+ [1.7 5.4 0.4]
+ [1.4 4.6 0.3]
+ [1.5 5.  0.2]
+ [1.4 4.4 0.2]
+ [1.5 4.9 0.1]], shape=(10, 3), dtype=float32)
 
+[[2]]
+tf.Tensor(
+[[3.5]
+ [3. ]
+ [3.2]
+ [3.1]
+ [3.6]
+ [3.9]
+ [3.4]
+ [3.4]
+ [2.9]
+ [3.1]], shape=(10, 1), dtype=float32)
+```
 
 ## Training loop
 
@@ -212,7 +240,7 @@ for (i in seq_len(n_epochs)) {
     
   })
   
-  cat("Total loss (epoch): ", i, ": ", total_loss$numpy(), "\n")
+  cat("Total loss (epoch): ", i, ": ", as.numeric(total_loss), "\n")
 }
 ```
 
@@ -284,8 +312,6 @@ Getting predictions on the test set is just a call to `model`, just like trainin
 model(x_test)
 ```
 
-> JJA: show output?
-
 
 ## Saving and restoring model weights
 
@@ -317,14 +343,11 @@ This call saves model weights only, not the complete graph. Thus on restore, you
 checkpoint$restore(tf$train$latest_checkpoint(checkpoint_dir))
 ```
 
-To get predictions from a freshly restored model, you need to pass in the test data as a tensor.
-Two ways to achieve this are shown below: using `k_constant` on `x_test` directly or using an iterator, like we do in the training loop.
+You can then obtain predictions from the restored model, on the test set as a whole or batch-wise, using an iterator.
 
 ```{r}
-# way 1 
-model(k_constant(x_test))
+model(x_test)
 
-# way 2
 iter <- make_iterator_one_shot(test_dataset)
 until_out_of_range({
   batch <-  iterator_get_next(iter)
@@ -339,8 +362,6 @@ until_out_of_range({
 Here is the complete example.
 
 ```{r}
-reticulate::use_condaenv("tf-10-gpu", required = TRUE)
-
 library(keras)
 use_implementation("tensorflow")
 
@@ -441,7 +462,7 @@ if (!restore) {
       
     })
     
-    cat("Total loss (epoch): ", i, ": ", total_loss$numpy(), "\n")
+    cat("Total loss (epoch): ", i, ": ", as.numeric(total_loss), "\n")
     
     checkpoint$save(file_prefix = checkpoint_prefix)
   }
@@ -452,10 +473,8 @@ if (!restore) {
 
 # Get model predictions on test set ---------------------------------------
 
-# way 1 
-model(k_constant(x_test))
+model(x_test)
 
-# way 2
 iter <- make_iterator_one_shot(test_dataset)
 until_out_of_range({
   batch <-  iterator_get_next(iter)

--- a/vignettes/eager_guide.Rmd
+++ b/vignettes/eager_guide.Rmd
@@ -1,0 +1,458 @@
+---
+title: "Keras with eager execution"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Keras with eager execution}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+type: docs
+repo: https://github.com/rstudio/keras
+menu:
+  main:
+    name: "Keras with eager execution"
+    identifier: "keras-eager"
+    parent: "keras-using-keras"
+    weight: 10
+    
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE, eval = FALSE)
+```
+
+Eager execution is a way to train a Keras model without building a graph. Operations return values, not tensors.
+Consequently, you can inspect what goes in and comes out of an operation simply by printing a variable's contents.
+This is an important advantage in model development and debugging.
+
+You can use eager execution with Keras as long as you use the TensorFlow implementation. This guide gives an outline of the workflow by way of a simple regression example. Specifically, you will see
+
+- how to set up your environment for eager execution
+- how to define the main ingredients: a Keras model, an optimizer and a loss function
+- how to feed data to the training routine
+- how to write a simple training loop that does backprop on the model's weights
+- how to make predictions on the test set
+- how to save the model's weights
+
+## Required minimum versions and "eager execution preamble"
+
+To use eager execution with Keras, you need a current version of the R package `keras` with a TensorFlow backend of version at least 1.9.
+
+The following preamble is required when using eager execution:
+
+```{r}
+library(keras)
+# make sure we use the tensorflow implementation of Keras
+# this line has to be executed immediately after loading the library
+use_implementation("tensorflow")
+
+library(tensorflow)
+# enable eager execution
+# the argument device_policy is needed only when using a GPU
+tfe_enable_eager_execution(device_policy = "silent")
+```
+
+When in doubt, check if you are in fact using eager execution:
+
+```{r}
+tf$executing_eagerly()
+```
+
+
+## Define a model
+
+Models for use with eager execution are defined as Keras [custom models](https://tensorflow.rstudio.com/keras/articles/custom_models.html).
+
+Custom models are usually made up of normal Keras layers, which you configure as usual. However, you are free to implement custom logic in the model's (implicit) _call_ function.
+
+Our simple regression example will use `iris` to predict `Sepal.Width` from `Petal.Length`, `Sepal.Length` and `Petal.Width`.
+
+Here is a model that can be used for that purpose:
+
+```{r}
+# model instantiator 
+create_model <- function(name = NULL) {
+  
+  keras_model_custom(name = name, function(self) {
+    # define any number of layers here
+    self$dense1 <- layer_dense(units = 32)
+    self$dropout <- layer_dropout(rate = 0.5)
+    self$dense2 <- layer_dense(units = 1)
+    
+    # this is the "call" function that defines what happens when the model is called
+    function (x, mask = NULL) {
+      self$dense1(x) %>%
+        self$dropout() %>%
+        self$dense2()
+    }
+  })
+}
+```
+
+
+The model is created simply by instantiating it via its wrapper:
+
+```{r}
+model <- create_model()
+```
+
+At this point, the shapes of the model's weights are still unknown (note how no `input_shape` has been defined for its first layer).
+You can, however, call the model on some test data already:
+
+```{r}
+model(k_constant(matrix(1:6, nrow = 2, ncol = 3)))
+```
+
+After that call, you can inspect the model's weights using 
+
+```{r}
+model$weights
+```
+
+This will not just display the tensor shapes, but the actual weight values.
+
+## Losses and optimizers
+
+An adequate loss function for a regression task like this is mean squared error:
+
+```{r}
+custom_loss <- function(y_true, y_pred, x) {
+  # can't use Keras loss_mean_squared_error() here
+  mse <- tf$losses$mean_squared_error(y_true, y_pred)
+  # here you could compute and add other losses 
+  mse
+}
+```
+
+Note how we have to use loss functions from TensorFlow, not the Keras equivalents. In the same vein, we need to use an optimizer from the `tf$train` module.
+
+```{r}
+# can't use Keras' optimizer_adam()
+optimizer <- tf$train$AdamOptimizer()
+```
+
+## Use tfdatasets to feed the data
+
+In eager execution, you use [tfdatasets](https://tensorflow.rstudio.com/tools/tfdatasets) to stream input and target data to the model.
+In our simple `iris` example, we use [tensor_slices_dataset](https://tensorflow.rstudio.com/tools/tfdatasets/reference/tensor_slices_dataset.html) to directly create a dataset from the underlying R matrices `x_train` and `y_train`.
+
+However, a wide variety of other [dataset creation](https://tensorflow.rstudio.com/tools/tfdatasets/reference/#section-creating-datasets) functions is available.
+Datasets also allow for a variety of pre-processing [transformations](https://tensorflow.rstudio.com/tools/tfdatasets/reference/#section-transforming-datasets).
+
+```{r}
+x_train <-
+  iris[1:120, c("Petal.Length", "Sepal.Length", "Petal.Width")] %>% as.matrix()
+y_train <-
+  iris[1:120, c("Sepal.Width")] %>% as.matrix()
+
+# use keras_array to convert to the correct floating point data type
+x_train <- keras_array(x_train)
+y_train <- keras_array(y_train)
+
+# same for test set
+x_test <-
+  iris[121:150, c("Petal.Length", "Sepal.Length", "Petal.Width")] %>% as.matrix()
+y_test <-
+  iris[121:150, c("Sepal.Width")] %>% as.matrix()
+x_test <- keras_array(x_test)
+y_test <- keras_array(y_test)
+
+library(tfdatasets)
+train_dataset <- tensor_slices_dataset(list (x_train, y_train)) %>% dataset_batch(10)
+test_dataset <- tensor_slices_dataset(list (x_test, y_test)) %>%
+  dataset_batch(10)
+```
+
+Data is accessed from a dataset via `make_iterator_one_shot` (to create an iterator) and `iterator_get_next` (to obtain the next batch).
+
+
+```{r}
+iter <- make_iterator_one_shot(train_dataset)
+batch <-  iterator_get_next(iter)
+```
+
+Datasets are available in non-eager (graph) execution as well. However, in eager mode, we can examine the actual values returned from the iterator:
+
+```{r}
+batch
+```
+
+
+## Training loop
+
+With eager execution, you have full control over the training process.
+
+In general, you will have at least two loops: an outer loop over epochs, and an inner loop over batches of data returned by the iterator (implemented implicitly by `until_out_of_range`).
+The iterator is recreated at the start of each new epoch.
+
+```{r}
+n_epochs <- 10
+
+for (i in seq_len(n_epochs)) {
+  
+  iter <- make_iterator_one_shot(train_dataset)
+  total_loss <- 0
+  
+  until_out_of_range({
+    
+    # get a new batch and run forward pass on it 
+    # calculate loss 
+    # calculate gradients of loss w.r.t. model weights
+    # update model weights
+    
+  })
+  
+  cat("Total loss (epoch): ", i, ": ", total_loss$numpy(), "\n")
+}
+```
+
+
+Filling in the missing pieces in the above outline, we will see that
+
+- Forward propagation is simply a call to `model()`.
+- This call has to happen inside the context of a `GradientTape` that records all operations.
+- Loss is calculated using the loss function defined before.
+- From the loss on the one hand and the model's current weights on the other hand, `GradientTape` then determines the gradients.
+- Finally, the optimizer applies the gradients to the weights in its algorithm-specific way.
+
+Here is the complete code for the training loop:
+
+```{r}
+n_epochs <- 10
+
+# loop over epochs
+for (i in seq_len(n_epochs)) {
+  
+  # create fresh iterator from dataset
+  iter <- make_iterator_one_shot(train_dataset)
+  # accumulate current epoch's loss (for display purposes only)
+  total_loss <- 0
+  
+  # loop once through the dataset
+  until_out_of_range({
+    batch <-  iterator_get_next(iter)
+    x <- batch[[1]]
+    y <- batch[[2]]
+    
+    # forward pass is recorded by tf$GradientTape
+    with(tf$GradientTape() %as% tape, {
+      # run model on current batch
+      preds <- model(x)
+      # with eager execution, if you wish you can inspect the predictions
+      # print(preds)
+      loss <- custom_loss(y, preds, x)
+    })
+    
+    total_loss <- total_loss + loss
+    
+    # get gradients of loss w.r.t. model weights
+    gradients <- tape$gradient(loss, model$variables)
+    # you could inspect the gradients, too
+    # print(gradients)
+    
+    # update model weights
+    optimizer$apply_gradients(
+      purrr::transpose(list(gradients, model$variables)),
+      global_step = tf$train$get_or_create_global_step()
+    )
+
+  })
+  
+  cat("Total loss (epoch): ", i, ": ", total_loss$numpy(), "\n")
+}
+
+```
+
+## Predictions on the test set
+
+Getting predictions on the test set is just a call to `model`, just like training has been.
+
+```{r}
+model(x_test)
+```
+
+
+## Saving and restoring model weights
+
+
+To save model weights, create an instance of `tf$Checkpoint` and pass it the objects to be saved: in our case, the `model` and the `optimizer`.
+This has to happen after the respective objects have been created, but before the training loop.
+
+```{r}
+checkpoint_dir <- "./checkpoints"
+checkpoint_prefix <- file.path(checkpoint_dir, "ckpt")
+checkpoint <-
+  tf$train$Checkpoint(
+    optimizer = optimizer,
+    model = model
+  )
+```
+
+
+Then at the end of each epoch, you save the model's current weights, like so:
+
+```{r}
+checkpoint$save(file_prefix = checkpoint_prefix)
+```
+
+This call saves model weights only, not the complete graph. Thus on restore, you re-create all components in the same way as above, and then load saved the model weights using e.g.
+
+```{r}
+# restore from recent checkpoint, you can also use a different one
+checkpoint$restore(tf$train$latest_checkpoint(checkpoint_dir))
+```
+
+To get predictions from a freshly restored model, you need to pass in the test data as a tensor.
+Two ways to achieve this are shown below: using `k_constant` on `x_test` directly or using an iterator, like we do in the training loop.
+
+```{r}
+# way 1 
+model(k_constant(x_test))
+
+# way 2
+iter <- make_iterator_one_shot(test_dataset)
+until_out_of_range({
+  batch <-  iterator_get_next(iter)
+  preds <- model(batch[[1]])
+  print(preds)
+})
+```
+
+
+## Complete example
+
+Here is the complete example.
+
+```{r}
+reticulate::use_condaenv("tf-10-gpu", required = TRUE)
+
+library(keras)
+use_implementation("tensorflow")
+
+library(tensorflow)
+tfe_enable_eager_execution(device_policy = "silent")
+
+library(tfdatasets)
+
+
+# Prepare training and test sets ------------------------------------------
+
+x_train <-
+  iris[1:120, c("Petal.Length", "Sepal.Length", "Petal.Width")] %>% as.matrix()
+x_train <- keras_array(x_train)
+y_train <-
+  iris[1:120, c("Sepal.Width")] %>% as.matrix()
+y_train <- keras_array(y_train)
+
+x_test <-
+  iris[121:150, c("Petal.Length", "Sepal.Length", "Petal.Width")] %>% as.matrix()
+x_test <- keras_array(x_test)
+y_test <-
+  iris[121:150, c("Sepal.Width")] %>% as.matrix()
+y_test <- keras_array(y_test)
+
+
+
+# Create datasets for training and testing --------------------------------
+
+train_dataset <- tensor_slices_dataset(list (x_train, y_train)) %>%
+  dataset_batch(10)
+test_dataset <- tensor_slices_dataset(list (x_test, y_test)) %>%
+  dataset_batch(10)
+
+
+# Create model ------------------------------------------------------------
+
+create_model <- function(name = NULL) {
+  keras_model_custom(name = name, function(self) {
+    self$dense1 <- layer_dense(units = 32, input_shape = 3)
+    self$dropout <- layer_dropout(rate = 0.5)
+    self$dense2 <- layer_dense(units = 1)
+    
+    function (x, mask = NULL) {
+      self$dense1(x) %>%
+        self$dropout() %>%
+        self$dense2()
+    }
+  })
+}
+
+model <- create_model()
+
+
+# Define loss function and optimizer --------------------------------------
+
+custom_loss <- function(y_true, y_pred, x) {
+  mse <- tf$losses$mean_squared_error(y_true, y_pred)
+  mse
+}
+
+optimizer <- tf$train$AdamOptimizer()
+
+
+# Set up checkpointing ----------------------------------------------------
+
+checkpoint_dir <- "./checkpoints"
+checkpoint_prefix <- file.path(checkpoint_dir, "ckpt")
+checkpoint <-
+  tf$train$Checkpoint(optimizer = optimizer,
+                      model = model)
+
+n_epochs <- 10
+
+# change to TRUE if you want to restore weights
+restore <- FALSE
+
+if (!restore) {
+  for (i in seq_len(n_epochs)) {
+    iter <- make_iterator_one_shot(train_dataset)
+    total_loss <- 0
+    
+    until_out_of_range({
+      batch <-  iterator_get_next(iter)
+      x <- batch[[1]]
+      y <- batch[[2]]
+      
+      with(tf$GradientTape() %as% tape, {
+        preds <- model(x)
+        loss <- custom_loss(y, preds, x)
+      })
+      
+      total_loss <- total_loss + loss
+      gradients <- tape$gradient(loss, model$variables)
+      
+      optimizer$apply_gradients(purrr::transpose(list(gradients, model$variables)),
+                                global_step = tf$train$get_or_create_global_step())
+      
+    })
+    
+    cat("Total loss (epoch): ", i, ": ", total_loss$numpy(), "\n")
+    
+    checkpoint$save(file_prefix = checkpoint_prefix)
+  }
+} else {
+  checkpoint$restore(tf$train$latest_checkpoint(checkpoint_dir))
+}
+
+
+# Get model predictions on test set ---------------------------------------
+
+# way 1 
+model(k_constant(x_test))
+
+# way 2
+iter <- make_iterator_one_shot(test_dataset)
+until_out_of_range({
+  batch <-  iterator_get_next(iter)
+  preds <- model(batch[[1]])
+  print(preds)
+})
+
+```
+
+
+## Where to from here
+
+In this guide, the task - and consequently, the custom model, associated loss and training routine - have been chosen for their simplicity.
+Visit the [TensorFlow for R blog](https://blogs.rstudio.com/tensorflow/) for case studies and paper implementations that use more intricate custom logic.
+
+

--- a/vignettes/eager_guide.Rmd
+++ b/vignettes/eager_guide.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Keras with eager execution"
+title: "Keras with Eager Execution"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Keras with eager execution}
@@ -24,16 +24,16 @@ Eager execution is a way to train a Keras model without building a graph. Operat
 Consequently, you can inspect what goes in and comes out of an operation simply by printing a variable's contents.
 This is an important advantage in model development and debugging.
 
-You can use eager execution with Keras as long as you use the TensorFlow implementation. This guide gives an outline of the workflow by way of a simple regression example. Specifically, you will see
+You can use eager execution with Keras as long as you use the TensorFlow implementation. This guide gives an outline of the workflow by way of a simple regression example. Specifically, you will see how to:
 
-- how to set up your environment for eager execution
-- how to define the main ingredients: a Keras model, an optimizer and a loss function
-- how to feed data to the training routine
-- how to write a simple training loop that does backprop on the model's weights
-- how to make predictions on the test set
-- how to save the model's weights
+- Set up your environment for eager execution
+- Define the main ingredients: a Keras model, an optimizer and a loss function
+- Feed data to the training routine
+- Write a simple training loop that does backprop on the model's weights
+- Make predictions on the test set
+- Save the model's weights
 
-## Required minimum versions and "eager execution preamble"
+## Requirements
 
 To use eager execution with Keras, you need a current version of the R package `keras` with a TensorFlow backend of version at least 1.9.
 
@@ -70,9 +70,10 @@ Here is a model that can be used for that purpose:
 
 ```{r}
 # model instantiator 
-create_model <- function(name = NULL) {
+iris_regression_model <- function(name = NULL) {
   
   keras_model_custom(name = name, function(self) {
+    
     # define any number of layers here
     self$dense1 <- layer_dense(units = 32)
     self$dropout <- layer_dropout(rate = 0.5)
@@ -80,7 +81,8 @@ create_model <- function(name = NULL) {
     
     # this is the "call" function that defines what happens when the model is called
     function (x, mask = NULL) {
-      self$dense1(x) %>%
+      x %>% 
+        self$dense1() %>%
         self$dropout() %>%
         self$dense2()
     }
@@ -92,11 +94,11 @@ create_model <- function(name = NULL) {
 The model is created simply by instantiating it via its wrapper:
 
 ```{r}
-model <- create_model()
+model <- iris_regression_model()
 ```
 
 At this point, the shapes of the model's weights are still unknown (note how no `input_shape` has been defined for its first layer).
-You can, however, call the model on some test data already:
+You can, however, already call the model on some test data:
 
 ```{r}
 model(k_constant(matrix(1:6, nrow = 2, ncol = 3)))
@@ -112,10 +114,13 @@ This will not just display the tensor shapes, but the actual weight values.
 
 ## Losses and optimizers
 
-An adequate loss function for a regression task like this is mean squared error:
+
+> JJA: We should explain why we need to use the tf loss and optimizer here
+
+An appropriate loss function for a regression task like this is mean squared error:
 
 ```{r}
-custom_loss <- function(y_true, y_pred, x) {
+mse_loss <- function(y_true, y_pred, x) {
   # can't use Keras loss_mean_squared_error() here
   mse <- tf$losses$mean_squared_error(y_true, y_pred)
   # here you could compute and add other losses 
@@ -144,20 +149,21 @@ x_train <-
 y_train <-
   iris[1:120, c("Sepal.Width")] %>% as.matrix()
 
-# use keras_array to convert to the correct floating point data type
-x_train <- keras_array(x_train)
-y_train <- keras_array(y_train)
+# Convert to approriate tensor floating point type for backend
+x_train <- k_constant(x_train)
+y_train <- k_constant(y_train)
 
 # same for test set
 x_test <-
   iris[121:150, c("Petal.Length", "Sepal.Length", "Petal.Width")] %>% as.matrix()
 y_test <-
   iris[121:150, c("Sepal.Width")] %>% as.matrix()
-x_test <- keras_array(x_test)
-y_test <- keras_array(y_test)
+x_test <- k_constant(x_test)
+y_test <- k_constant(y_test)
 
 library(tfdatasets)
-train_dataset <- tensor_slices_dataset(list (x_train, y_train)) %>% dataset_batch(10)
+train_dataset <- tensor_slices_dataset(list (x_train, y_train)) %>% 
+  dataset_batch(10)
 test_dataset <- tensor_slices_dataset(list (x_test, y_test)) %>%
   dataset_batch(10)
 ```
@@ -176,10 +182,12 @@ Datasets are available in non-eager (graph) execution as well. However, in eager
 batch
 ```
 
+> JJA: show output for simple data inspection (another case up above)
+
 
 ## Training loop
 
-With eager execution, you have full control over the training process.
+With eager execution, you take full control over the training process.
 
 In general, you will have at least two loops: an outer loop over epochs, and an inner loop over batches of data returned by the iterator (implemented implicitly by `until_out_of_range`).
 The iterator is recreated at the start of each new epoch.
@@ -195,8 +203,11 @@ for (i in seq_len(n_epochs)) {
   until_out_of_range({
     
     # get a new batch and run forward pass on it 
+    
     # calculate loss 
+    
     # calculate gradients of loss w.r.t. model weights
+    
     # update model weights
     
   })
@@ -224,30 +235,33 @@ for (i in seq_len(n_epochs)) {
   
   # create fresh iterator from dataset
   iter <- make_iterator_one_shot(train_dataset)
+  
   # accumulate current epoch's loss (for display purposes only)
   total_loss <- 0
   
   # loop once through the dataset
   until_out_of_range({
+    
+    # get next batch
     batch <-  iterator_get_next(iter)
     x <- batch[[1]]
     y <- batch[[2]]
     
     # forward pass is recorded by tf$GradientTape
     with(tf$GradientTape() %as% tape, {
+     
       # run model on current batch
       preds <- model(x)
-      # with eager execution, if you wish you can inspect the predictions
-      # print(preds)
-      loss <- custom_loss(y, preds, x)
+     
+      # compute the loss
+      loss <- mse_loss(y, preds, x)
     })
     
+    # update total loss
     total_loss <- total_loss + loss
     
     # get gradients of loss w.r.t. model weights
     gradients <- tape$gradient(loss, model$variables)
-    # you could inspect the gradients, too
-    # print(gradients)
     
     # update model weights
     optimizer$apply_gradients(
@@ -257,7 +271,7 @@ for (i in seq_len(n_epochs)) {
 
   })
   
-  cat("Total loss (epoch): ", i, ": ", total_loss$numpy(), "\n")
+  cat("Total loss (epoch): ", i, ": ", as.numeric(total_loss), "\n")
 }
 
 ```
@@ -269,6 +283,8 @@ Getting predictions on the test set is just a call to `model`, just like trainin
 ```{r}
 model(x_test)
 ```
+
+> JJA: show output?
 
 
 ## Saving and restoring model weights
@@ -338,17 +354,17 @@ library(tfdatasets)
 
 x_train <-
   iris[1:120, c("Petal.Length", "Sepal.Length", "Petal.Width")] %>% as.matrix()
-x_train <- keras_array(x_train)
+x_train <- k_constant(x_train)
 y_train <-
   iris[1:120, c("Sepal.Width")] %>% as.matrix()
-y_train <- keras_array(y_train)
+y_train <- k_constant(y_train)
 
 x_test <-
   iris[121:150, c("Petal.Length", "Sepal.Length", "Petal.Width")] %>% as.matrix()
-x_test <- keras_array(x_test)
+x_test <- k_constant(x_test)
 y_test <-
   iris[121:150, c("Sepal.Width")] %>% as.matrix()
-y_test <- keras_array(y_test)
+y_test <- k_constant(y_test)
 
 
 
@@ -362,7 +378,7 @@ test_dataset <- tensor_slices_dataset(list (x_test, y_test)) %>%
 
 # Create model ------------------------------------------------------------
 
-create_model <- function(name = NULL) {
+iris_regression_model <- function(name = NULL) {
   keras_model_custom(name = name, function(self) {
     self$dense1 <- layer_dense(units = 32, input_shape = 3)
     self$dropout <- layer_dropout(rate = 0.5)
@@ -376,12 +392,12 @@ create_model <- function(name = NULL) {
   })
 }
 
-model <- create_model()
+model <- iris_regression_model()
 
 
 # Define loss function and optimizer --------------------------------------
 
-custom_loss <- function(y_true, y_pred, x) {
+mse_loss <- function(y_true, y_pred, x) {
   mse <- tf$losses$mean_squared_error(y_true, y_pred)
   mse
 }
@@ -414,7 +430,7 @@ if (!restore) {
       
       with(tf$GradientTape() %as% tape, {
         preds <- model(x)
-        loss <- custom_loss(y, preds, x)
+        loss <- mse_loss(y, preds, x)
       })
       
       total_loss <- total_loss + loss

--- a/vignettes/getting_started.Rmd
+++ b/vignettes/getting_started.Rmd
@@ -210,19 +210,17 @@ The [Deep Learning with Keras](https://github.com/rstudio/cheatsheets/raw/master
 
 To learn more about Keras, you can check out these articles:
 
-- [Guide to the Sequential Model](articles/sequential_model.html)
+- [Guide to the Sequential Model](sequential_model.html)
 
-- [Guide to the Functional API](articles/functional_api.html)
+- [Guide to the Functional API](functional_api.html)
 
-- [Frequently Asked Questions](articles/faq.html)
+- [Frequently Asked Questions](faq.html)
 
-- [Training Visualization](articles/training_visualization.html)
+- [Training Visualization](training_visualization.html)
 
-- [Using Pre-Trained Models](articles/applications.html)
+- [Using Pre-Trained Models](applications.html)
 
-The [examples](articles/examples/index.html) demonstrate more advanced models including transfer learning, variational auto-encoding, question-answering with memory networks, text generation with stacked LSTMs, etc.
-
-The [function reference](reference/index.html) includes detailed information on all of the functions available in the package.
+- [Keras with Eager Execution](eager_guide.html)
 
 [![](https://images.manning.com/720/960/resize/book/a/4e5e97f-4e8d-4d97-a715-f6c2b0eb95f5/Allaire-DLwithR-HI.png){width=125 align=right style="margin-left:10px; margin-right: 20px; margin-top: 15px; border: solid 1px #cccccc;"}](https://www.amazon.com/Deep-Learning-R-Francois-Chollet/dp/161729554X)
 

--- a/vignettes/guide_keras.Rmd
+++ b/vignettes/guide_keras.Rmd
@@ -491,7 +491,7 @@ model <- load_model_hdf5('my_model.h5')
 
 ## Eager execution
 
-TensorFlow [Eager execution](https://www.tensorflow.org/guide/eager) is an imperative programming environment that evaluates operations immediately. This is not required for Keras,
+[Eager execution](eager_guide.Rmd) is an imperative programming environment that evaluates operations immediately. This is not required for Keras,
 but is supported by the TensorFlow backend and useful for inspecting your program
 and debugging.
 
@@ -506,8 +506,6 @@ use_implementation("tensorflow")
 When using the TensorFlow implementation,  all model-building APIs are compatible with eager
 execution. 
 
-Consult the [RStudio TensorFlow blog](https://blogs.rstudio.com/tensorflow/) for examples
-using eager execution.
 
 ## Distribution
 


### PR DESCRIPTION
Something I wasn't aware of before: that you need to convert to tensor before getting predictions in case you've restored weights for a model that's never been called (because the test data now have to provide shape information).
I'm showing 2 ways which I think is okay - the iterator way would be necessary anyway if one had bigger test sets... but for the other, do you think I'd better leave it out (to avoid confusion)?
Alternatively, I wonder if it makes sense to have something like `as_tensor` that more clearly indicates the intent (afaik we don't have that right?)?