### PR TITLE
newer versions use keras_preprocessing module name

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -963,6 +963,15 @@ is_main_thread_generator.keras.preprocessing.image.Iterator <- function(x) {
   }
 }
 
+is_main_thread_generator.keras_preprocessing.image.Iterator <- function(x) {
+  if (py_has_attr(x, "image_data_generator")) {
+    generator <- x$image_data_generator
+    !is.null(generator$preprocessing_function)
+  } else {
+    FALSE
+  }
+}
+
 is_tensorflow_dataset <- function(x) {
   inherits(x, "tensorflow.python.data.ops.dataset_ops.Dataset")
 }


### PR DESCRIPTION
This just duplicates the code of course, but perhaps is the safest way at the moment?
(Assuming one could be removed later some time....)
Or should we query which is used and set a variable for that?

fix for https://github.com/rstudio/keras/issues/225