### PR TITLE
Tell people how to override RETICULATE_PYTHON

### DIFF
--- a/vignettes/getting_started.Rmd
+++ b/vignettes/getting_started.Rmd
@@ -45,7 +45,7 @@ install_keras()
 ```
 
 This will provide you with default CPU-based installations of Keras and TensorFlow. If you want a more customized installation, e.g. if you want to take advantage of NVIDIA GPUs, see the documentation for `install_keras()`.
-
+If you have set a specific version of Python to use, you may need to unset it, e.g. with `Sys.unsetenv(x = "RETICULATE_PYTHON")`, at the beginning of a session that uses Keras.
 
 ## MNIST Example
 


### PR DESCRIPTION
For people who have set this variable, keras may fail in a way that's hard to debug (I got this message):

``` r
library(keras)
# Sys.unsetenv(x = "RETICULATE_PYTHON")
fashion_mnist <- dataset_fashion_mnist()
#> Error: ModuleNotFoundError: No module named 'tensorflow'
#> 
#> Detailed traceback: 
#>   File "/home/robin/.local/lib/python3.6/site-packages/keras/__init__.py", line 3, in <module>
#>     from . import utils
#>   File "/home/robin/.local/lib/python3.6/site-packages/keras/utils/__init__.py", line 6, in <module>
#>     from . import conv_utils
#>   File "/home/robin/.local/lib/python3.6/site-packages/keras/utils/conv_utils.py", line 9, in <module>
#>     from .. import backend as K
#>   File "/home/robin/.local/lib/python3.6/site-packages/keras/backend/__init__.py", line 89, in <module>
#>     from .tensorflow_backend import *
#>   File "/home/robin/.local/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 5, in <module>
#>     import tensorflow as tf
```

<sup>Created on 2018-11-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

After running the command added in this PR it works: 

``` r
library(keras)
Sys.unsetenv(x = "RETICULATE_PYTHON")
fashion_mnist <- dataset_fashion_mnist()
```

<sup>Created on 2018-11-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>