### PR TITLE
Fix bad practices in R

### DIFF
--- a/vignettes/examples/variational_autoencoder.R
+++ b/vignettes/examples/variational_autoencoder.R
@@ -68,10 +68,10 @@ vae %>% compile(optimizer = "rmsprop", loss = vae_loss)
 # Data preparation --------------------------------------------------------
 
 mnist <- dataset_mnist()
-x_train <- mnist$train$x/255
-x_test <- mnist$test$x/255
-x_train <- x_train %>% apply(1, as.numeric) %>% t()
-x_test <- x_test %>% apply(1, as.numeric) %>% t()
+dim_ts <- dim(mnist$test$x)
+dim_tr <- dim(mnist$train$x)
+x_test <- array(mnist$test$x / 255, c(dim_ts[1], prod(dim_ts[-1])))
+x_train <- array(mnist$train$x / 255, c(dim_tr[1], prod(dim_tr[-1])))
 
 
 # Model training ----------------------------------------------------------


### PR DESCRIPTION
`apply(1, as.numeric)` is basically running a loop by row- a very bad practice in R. Not to mention that there is no need to convert already numeric values to numeric again (by row!)

We can easily avoid it by just reshaping the data (similar like you would do with `numpy.reshape` in python)

Below are some benchmarks (the difference will become more evident as the data set will grow)- on my machine it's about **X15** times faster

```r
library(keras)
mnist <- dataset_mnist()

system.time({
  
  x_train <- mnist$train$x / 255
  x_test <- mnist$test$x / 255
  x_train <- x_train %>% apply(1, as.numeric) %>% t()
  x_test <- x_test %>% apply(1, as.numeric) %>% t()
  
})

# user  system elapsed 
# 2.08    0.98    3.08 

system.time({
  
  dim_ts <- dim(mnist$test$x)
  dim_tr <- dim(mnist$train$x)
  x_test_2 <- array(mnist$test$x / 255, c(dim_ts[1], prod(dim_ts[-1])))
  x_train_2 <- array(mnist$train$x / 255, c(dim_tr[1], prod(dim_tr[-1])))
  
})

# user  system elapsed 
# 0.2     0.0     0.2 

identical(x_train, x_train_2)
# [1] TRUE
identical(x_test, x_test_2)
# [1] TRUE
```