### PR TITLE
generalize to accommodate other underlying python classes

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -973,7 +973,7 @@ is_main_thread_generator.keras_preprocessing.image.Iterator <- function(x) {
 }
 
 is_tensorflow_dataset <- function(x) {
-  inherits(x, "tensorflow.python.data.ops.dataset_ops.Dataset")
+  inherits(x, "tf_dataset")
 }
 
 resolve_tensorflow_dataset <- function(x) {


### PR DESCRIPTION
With TF > 1.12, the inheritance hierarchy for datasets does not include `tensorflow.python.data.ops.dataset_ops.Dataset` anymore.
We could alternatively look for an additional superclass, but the way used below should be fine too, because in R, all datasets receive the additional class `tf_dataset`... LMK if this okay or we would prefer the alternative approach.