### PR TITLE
switch to tf.keras as default implementation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 
+## Development version
+
+- Use `tf.keras` as default implementation module.
+
+
 ## Keras 2.2.4 (CRAN)
 
 - Improve handling of `timeseries_generator()` in calls to `fit_generator()`

--- a/R/package.R
+++ b/R/package.R
@@ -77,6 +77,7 @@ use_backend <- function(backend = c("tensorflow", "cntk", "theano", "plaidml")) 
   } else {
     Sys.setenv(KERAS_BACKEND = match.arg(backend))
   }
+  if (backend != "tensorflow") use_implementation("keras")
 }
 
 
@@ -87,6 +88,8 @@ keras <- NULL
   
   # resolve the implementaiton module (might be keras proper or might be tensorflow)
   implementation_module <- resolve_implementation_module()
+  if (implementation_module == "tensorflow.python.keras")
+    Sys.setenv(KERAS_IMPLEMENTATION = "tensorflow")
   
   # if KERAS_PYTHON is defined then forward it to RETICULATE_PYTHON
   keras_python <- get_keras_python()
@@ -160,7 +163,7 @@ resolve_implementation_module <- function() {
   implementation_module
 }
 
-get_keras_implementation <- function(default = "keras") {
+get_keras_implementation <- function(default = "tensorflow") {
   get_keras_option("KERAS_IMPLEMENTATION", default = default)
 }
 

--- a/R/package.R
+++ b/R/package.R
@@ -88,9 +88,7 @@ keras <- NULL
   
   # resolve the implementaiton module (might be keras proper or might be tensorflow)
   implementation_module <- resolve_implementation_module()
-  if (implementation_module == "tensorflow.python.keras")
-    Sys.setenv(KERAS_IMPLEMENTATION = "tensorflow")
-  
+
   # if KERAS_PYTHON is defined then forward it to RETICULATE_PYTHON
   keras_python <- get_keras_python()
   if (!is.null(keras_python))

--- a/inst/python/kerastools/layer.py
+++ b/inst/python/kerastools/layer.py
@@ -1,7 +1,7 @@
 
 import os
 
-if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'keras'):
+if (os.getenv('KERAS_IMPLEMENTATION', 'tensorflow') == 'keras'):
   from keras.engine.topology import Layer
   def shape_filter(shape):
     return shape

--- a/inst/python/kerastools/layer.py
+++ b/inst/python/kerastools/layer.py
@@ -1,17 +1,18 @@
 
 import os
 
-if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'tensorflow'):
+if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'keras'):
+  from keras.engine.topology import Layer
+  def shape_filter(shape):
+    return shape
+else:
   from tensorflow.python.keras.engine import Layer
   def shape_filter(shape):
     if not isinstance(shape, list):
       return shape.as_list()
     else:
       return shape
-else:
-  from keras.engine.topology import Layer
-  def shape_filter(shape):
-    return shape
+  
 
 class RLayer(Layer):
 

--- a/inst/python/kerastools/model.py
+++ b/inst/python/kerastools/model.py
@@ -2,7 +2,7 @@
 
 import os
 
-if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'keras'):
+if (os.getenv('KERAS_IMPLEMENTATION', 'tensorflow') == 'keras'):
   from keras.engine import Model
 else:
   try:

--- a/inst/python/kerastools/model.py
+++ b/inst/python/kerastools/model.py
@@ -2,15 +2,14 @@
 
 import os
 
-if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'tensorflow'):
+if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'keras'):
+  from keras.engine import Model
+else:
   try:
     from tensorflow.python.keras.engine import Model
   except:
     from tensorflow.python.keras.engine.training import Model
-else:
-  from keras.engine import Model
- 
- 
+
 class RModel(Model):
 
   def __init__(self, name = None):

--- a/inst/python/kerastools/wrapper.py
+++ b/inst/python/kerastools/wrapper.py
@@ -1,17 +1,17 @@
 import os
 
-if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'tensorflow'):
+if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'keras'):
+  from keras.layers import Wrapper
+  def shape_filter(shape): 
+    return shape
+else:
   from tensorflow.python.keras.layers import Wrapper
   def shape_filter(shape):
     if not isinstance(shape, list):
       return shape.as_list()
     else:
       return shape
-else:
-  from keras.layers import Wrapper
-  def shape_filter(shape):
-    return shape
-
+ 
 class RWrapper(Wrapper):
 
   def __init__(self, r_build, r_call, r_compute_output_shape, **kwargs):

--- a/inst/python/kerastools/wrapper.py
+++ b/inst/python/kerastools/wrapper.py
@@ -1,6 +1,6 @@
 import os
 
-if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'keras'):
+if (os.getenv('KERAS_IMPLEMENTATION', 'tensorflow') == 'keras'):
   from keras.layers import Wrapper
   def shape_filter(shape): 
     return shape

--- a/tests/testthat/test-model-persistence.R
+++ b/tests/testthat/test-model-persistence.R
@@ -115,7 +115,7 @@ test_succeeds("model can be exported to TensorFlow", {
   
   export <- function() tensorflow::export_savedmodel(model, model_dir)
   
-  if (grepl("^tensorflow", Sys.getenv("KERAS_IMPLEMENTATION"))) {
+  if (!grepl("^keras", Sys.getenv("KERAS_IMPLEMENTATION"))) {
     expect_error(export())
   }
   else {


### PR DESCRIPTION
In addition to what we said, I had to set 
```
KERAS_IMPLEMENTATION = "tensorflow"
```
somewhere, because the Python classes need it:

```
if (os.getenv('KERAS_IMPLEMENTATION', 'keras') == 'tensorflow'):
```


LMK if there's a better place than line 91/92 where I'm doing it (tried various ways of doing this as a side effect from called methods but that failed on package load, this is why I'm doing it there.)

With that change, all tests pass (TF 1.x only, so far). 

The update to NEWS.md is just "improvised", but it seems we also have to rethink version numbering, now that we basically depend on TF releases...

