### PR TITLE
Add new callbacks moments

### DIFF
--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -371,8 +371,10 @@ callback_csv_logger <- function(filename, separator = ",", append = FALSE) {
 #' 
 #' @param on_epoch_begin called at the beginning of every epoch.
 #' @param on_epoch_end called at the end of every epoch.
-#' @param on_batch_begin called at the beginning of every batch.
-#' @param on_batch_end called at the end of every batch.
+#' @param on_batch_begin called at the beginning of every training batch.
+#' @param on_batch_end called at the end of every training batch.
+#' @param on_train_batch_begin called at the beginning of every batch.
+#' @param on_train_batch_end called at the end of every batch.
 #' @param on_train_begin called at the beginning of model training.
 #' @param on_train_end called at the end of model training.
 #' @param on_predict_batch_begin called at the beginning of a batch in predict methods.

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -559,6 +559,8 @@ normalize_callbacks <- function(callbacks) {
         r_on_epoch_end = callback$on_epoch_end,
         r_on_train_begin = callback$on_train_begin,
         r_on_train_end = callback$on_train_end,
+        r_on_batch_begin = callback$on_batch_begin,
+        r_on_batch_end = callback$on_batch_end,
         r_on_predict_batch_begin = callback$on_predict_batch_begin,
         r_on_predict_batch_end = callback$on_predict_batch_end,
         r_on_predict_begin = callback$on_predict_begin,

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -475,7 +475,48 @@ KerasCallback <- R6Class("KerasCallback",
     
     on_train_end = function(logs = NULL) {
       
+    },
+    
+    on_predict_batch_begin = function(batch, logs = NULL) {
+      
+    },
+    
+    on_predict_batch_end = function(batch, logs = NULL) {
+      
+    },
+    
+    on_predict_begin = function(logs = NULL) {
+      
+    },
+    
+    on_predict_end = function(logs = NULL) {
+      
+    },
+    
+    on_test_batch_begin = function(batch, logs = NULL) {
+      
+    },
+    
+    on_test_batch_end = function(batch, logs = NULL) {
+      
+    },
+    
+    on_test_begin = function(logs = NULL) {
+      
+    },
+    
+    on_test_end = function(logs = NULL) {
+      
+    },
+    
+    on_train_batch_begin = function(batch, logs = NULL) {
+      
+    },
+    
+    on_train_batch_end = function(batch, logs = NULL) {
+      
     }
+    
   )
 )
 
@@ -486,7 +527,8 @@ normalize_callbacks <- function(view_metrics, callbacks) {
     callbacks <- list(callbacks)
   
   # always include the metrics callback
-  callbacks <- append(callbacks, KerasMetricsCallback$new(view_metrics))  
+  if (!is.na(view_metrics))
+    callbacks <- append(callbacks, KerasMetricsCallback$new(view_metrics))  
  
   # import callback utility module
   python_path <- system.file("python", package = "keras")
@@ -510,7 +552,17 @@ normalize_callbacks <- function(view_metrics, callbacks) {
         r_on_batch_begin = callback$on_batch_begin,
         r_on_batch_end = callback$on_batch_end,
         r_on_train_begin = callback$on_train_begin,
-        r_on_train_end = callback$on_train_end
+        r_on_train_end = callback$on_train_end,
+        r_on_predict_batch_begin = callback$on_predict_batch_begin,
+        r_on_predict_batch_end = callback$on_predict_batch_end,
+        r_on_predict_begin = callback$on_predict_begin,
+        r_on_predict_end = callback$on_predict_end,
+        r_on_test_batch_begin = callback$on_test_batch_begin,
+        r_on_test_batch_end = callback$on_test_batch_end,
+        r_on_test_begin = callback$on_test_begin,
+        r_on_test_end = callback$on_test_end,
+        r_on_train_batch_begin = callback$on_train_batch_begin,
+        r_on_train_batch_end = callback$on_train_batch_end
       )
     } else {
       callback

--- a/R/model.R
+++ b/R/model.R
@@ -538,7 +538,7 @@ evaluate.keras.engine.training.Model <- function(object, x = NULL, y = NULL, bat
 }
 
 resolve_callbacks <- function(args, callbacks) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "1.13.1") {
+  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0") {
     args <- append(args, list(callbacks = normalize_callbacks(callbacks)))
   } else if (!is.null(callbacks)) {
     warning("Prediction callbacks are only supported for TensorFlow ",

--- a/R/model.R
+++ b/R/model.R
@@ -554,7 +554,8 @@ evaluate.keras.engine.training.Model <- function(object, x = NULL, y = NULL, bat
 #' 
 #' @importFrom stats predict
 #' @export
-predict.keras.engine.training.Model <- function(object, x, batch_size=NULL, verbose=0, steps=NULL, ...) {
+predict.keras.engine.training.Model <- function(object, x, batch_size=NULL, verbose=0, steps=NULL, 
+                                                callbacks = NULL,...) {
   
   # defaults
   if (is.null(batch_size) && is.null(steps))
@@ -563,7 +564,8 @@ predict.keras.engine.training.Model <- function(object, x, batch_size=NULL, verb
   # args
   args <- list(
     batch_size = as_nullable_integer(batch_size),
-    verbose = as.integer(verbose)
+    verbose = as.integer(verbose),
+    callbacks = normalize_callbacks(NA, callbacks)
   )
   
   # resolve x (check for TF dataset)

--- a/R/model.R
+++ b/R/model.R
@@ -564,9 +564,15 @@ predict.keras.engine.training.Model <- function(object, x, batch_size=NULL, verb
   # args
   args <- list(
     batch_size = as_nullable_integer(batch_size),
-    verbose = as.integer(verbose),
-    callbacks = normalize_callbacks(callbacks)
+    verbose = as.integer(verbose)
   )
+  
+  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0) {
+    args <- append(args, callbacks = normalize_callbacks(callbacks))
+  } else if (!is.null(callbacks)) {
+    warning("Prediction callbacks are only supported for TensorFlow ",
+            "implementation of Keras. And tf_version() >= 2.0")
+  }
   
   # resolve x (check for TF dataset)
   dataset <- resolve_tensorflow_dataset(x)

--- a/R/model.R
+++ b/R/model.R
@@ -422,7 +422,7 @@ fit.keras.engine.training.Model <-
     batch_size = as_nullable_integer(batch_size),
     epochs = as.integer(epochs),
     verbose = as.integer(verbose),
-    callbacks = normalize_callbacks(view_metrics, callbacks),
+    callbacks = normalize_callbacks_with_metrics(view_metrics, callbacks),
     validation_split = validation_split,
     shuffle = shuffle,
     class_weight = as_class_weight(class_weight),
@@ -565,7 +565,7 @@ predict.keras.engine.training.Model <- function(object, x, batch_size=NULL, verb
   args <- list(
     batch_size = as_nullable_integer(batch_size),
     verbose = as.integer(verbose),
-    callbacks = normalize_callbacks(NA, callbacks)
+    callbacks = normalize_callbacks(callbacks)
   )
   
   # resolve x (check for TF dataset)
@@ -779,7 +779,7 @@ fit_generator <- function(object, generator, steps_per_epoch, epochs = 1,
     steps_per_epoch = as.integer(steps_per_epoch),
     epochs = as.integer(epochs),
     verbose = as.integer(verbose),
-    callbacks = normalize_callbacks(view_metrics, callbacks),
+    callbacks = normalize_callbacks_with_metrics(view_metrics, callbacks),
     validation_data = validation_data,
     validation_steps = as_nullable_integer(validation_steps),
     class_weight = as_class_weight(class_weight),

--- a/R/model.R
+++ b/R/model.R
@@ -545,6 +545,7 @@ evaluate.keras.engine.training.Model <- function(object, x = NULL, y = NULL, bat
 #' @param x Input data (vector, matrix, or array)
 #' @param batch_size Integer. If unspecified, it will default to 32.
 #' @param verbose Verbosity mode, 0 or 1.
+#' @param callbacks List of callbacks to apply during prediction. 
 #' @param ... Unused
 #' 
 #' @return vector, matrix, or array of predictions
@@ -568,7 +569,7 @@ predict.keras.engine.training.Model <- function(object, x, batch_size=NULL, verb
   )
   
   if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0) {
-    args <- append(args, callbacks = normalize_callbacks(callbacks))
+    args <- append(args, list(callbacks = normalize_callbacks(callbacks)))
   } else if (!is.null(callbacks)) {
     warning("Prediction callbacks are only supported for TensorFlow ",
             "implementation of Keras. And tf_version() >= 2.0")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 # DO NOT CHANGE the "init" and "install" sections below
 
 environment:
+  USE_RTOOLS: true
   matrix:
     - TF_VERSION: 1.13.1
     - TF_VERSION: 1.12.0

--- a/inst/python/kerastools/callback.py
+++ b/inst/python/kerastools/callback.py
@@ -15,7 +15,18 @@ class RCallback(Callback):
                      r_on_batch_begin,
                      r_on_batch_end,
                      r_on_train_begin,
-                     r_on_train_end):
+                     r_on_train_end,
+                     r_on_predict_batch_begin,
+                     r_on_predict_batch_end,
+                     r_on_predict_begin,
+                     r_on_predict_end,
+                     r_on_test_batch_begin,
+                     r_on_test_batch_end,
+                     r_on_test_begin,
+                     r_on_test_end,
+                     r_on_train_batch_begin,
+                     r_on_train_batch_end
+                     ):
     super(Callback, self).__init__()
     self.r_set_context = r_set_context
     self.r_on_epoch_begin = r_on_epoch_begin
@@ -24,6 +35,16 @@ class RCallback(Callback):
     self.r_on_batch_end = r_on_batch_end
     self.r_on_train_begin = r_on_train_begin
     self.r_on_train_end = r_on_train_end
+    self.r_on_predict_batch_begin = r_on_predict_batch_begin
+    self.r_on_predict_batch_end = r_on_predict_batch_end
+    self.r_on_predict_begin = r_on_predict_begin
+    self.r_on_predict_end = r_on_predict_end
+    self.r_on_test_batch_begin = r_on_test_batch_begin
+    self.r_on_test_batch_end = r_on_test_batch_end
+    self.r_on_test_begin = r_on_test_begin
+    self.r_on_test_end = r_on_test_end
+    self.r_on_train_batch_begin = r_on_train_batch_begin
+    self.r_on_train_batch_end = r_on_train_batch_end
   
   def on_epoch_begin(self, epoch, logs=None):
     self.r_on_epoch_begin(epoch, logs)
@@ -40,9 +61,36 @@ class RCallback(Callback):
   def on_train_begin(self, logs=None):
     self.r_set_context(self.params, self.model)
     self.r_on_train_begin(logs)
- 
+    
   def on_train_end(self, logs=None):
     self.r_on_train_end(logs)
  
-
- 
+  def on_predict_batch_begin(self, batch, logs=None):
+    self.r_on_predict_batch_begin(batch, logs)
+    
+  def on_predict_batch_end(self, batch, logs=None):
+    self.r_on_predict_batch_end(batch, logs)
+    
+  def on_predict_begin(self, logs=None):
+    self.r_on_predict_begin(logs)
+    
+  def on_predict_end(self, logs=None):
+    self.r_on_predict_end(logs)
+  
+  def on_test_batch_begin(self, batch, logs=None):
+    self.r_on_test_batch_begin(batch, logs)
+    
+  def on_test_batch_end(self, batch, logs=None):
+    self.r_on_test_batch_end(batch, logs)
+    
+  def on_test_begin(self, logs=None):
+    self.r_on_test_begin(logs)
+    
+  def on_test_end(self, logs=None):
+    self.r_on_test_end(logs)
+    
+  def on_train_batch_begin(self, batch, logs=None):
+    self.r_on_train_batch_begin(batch, logs)
+    
+  def on_train_batch_end(self, batch, logs=None):
+    self.r_on_train_batch_end(batch, logs)

--- a/inst/python/kerastools/callback.py
+++ b/inst/python/kerastools/callback.py
@@ -14,6 +14,8 @@ class RCallback(Callback):
                      r_on_epoch_end,
                      r_on_train_begin,
                      r_on_train_end,
+                     r_on_batch_begin,
+                     r_on_batch_end,
                      r_on_predict_batch_begin,
                      r_on_predict_batch_end,
                      r_on_predict_begin,
@@ -31,6 +33,8 @@ class RCallback(Callback):
     self.r_on_epoch_end = r_on_epoch_end
     self.r_on_train_begin = r_on_train_begin
     self.r_on_train_end = r_on_train_end
+    self.r_on_batch_begin = r_on_batch_begin
+    self.r_on_batch_end = r_on_batch_end
     self.r_on_predict_batch_begin = r_on_predict_batch_begin
     self.r_on_predict_batch_end = r_on_predict_batch_end
     self.r_on_predict_begin = r_on_predict_begin
@@ -54,6 +58,12 @@ class RCallback(Callback):
     
   def on_train_end(self, logs=None):
     self.r_on_train_end(logs)
+  
+  def on_batch_begin(self, batch, logs=None):
+    self.r_on_batch_begin(batch, logs)
+    
+  def on_batch_end(self, batch, logs=None):
+    self.r_on_batch_end(batch, logs)
  
   def on_predict_batch_begin(self, batch, logs=None):
     self.r_on_predict_batch_begin(batch, logs)

--- a/inst/python/kerastools/callback.py
+++ b/inst/python/kerastools/callback.py
@@ -12,8 +12,6 @@ class RCallback(Callback):
   def __init__(self, r_set_context,
                      r_on_epoch_begin,
                      r_on_epoch_end,
-                     r_on_batch_begin,
-                     r_on_batch_end,
                      r_on_train_begin,
                      r_on_train_end,
                      r_on_predict_batch_begin,
@@ -31,8 +29,6 @@ class RCallback(Callback):
     self.r_set_context = r_set_context
     self.r_on_epoch_begin = r_on_epoch_begin
     self.r_on_epoch_end = r_on_epoch_end
-    self.r_on_batch_begin = r_on_batch_begin
-    self.r_on_batch_end = r_on_batch_end
     self.r_on_train_begin = r_on_train_begin
     self.r_on_train_end = r_on_train_end
     self.r_on_predict_batch_begin = r_on_predict_batch_begin
@@ -51,12 +47,6 @@ class RCallback(Callback):
 
   def on_epoch_end(self, epoch, logs=None):
     self.r_on_epoch_end(epoch, logs)
-
-  def on_batch_begin(self, batch, logs=None):
-    self.r_on_batch_begin(batch, logs)
- 
-  def on_batch_end(self, batch, logs=None):
-    self.r_on_batch_end(batch, logs)
 
   def on_train_begin(self, logs=None):
     self.r_set_context(self.params, self.model)

--- a/man/callback_lambda.Rd
+++ b/man/callback_lambda.Rd
@@ -5,8 +5,13 @@
 \title{Create a custom callback}
 \usage{
 callback_lambda(on_epoch_begin = NULL, on_epoch_end = NULL,
-  on_batch_begin = NULL, on_batch_end = NULL, on_train_begin = NULL,
-  on_train_end = NULL)
+  on_batch_begin = NULL, on_batch_end = NULL,
+  on_train_batch_begin = NULL, on_train_batch_end = NULL,
+  on_train_begin = NULL, on_train_end = NULL,
+  on_predict_batch_begin = NULL, on_predict_batch_end = NULL,
+  on_predict_begin = NULL, on_predict_end = NULL,
+  on_test_batch_begin = NULL, on_test_batch_end = NULL,
+  on_test_begin = NULL, on_test_end = NULL)
 }
 \arguments{
 \item{on_epoch_begin}{called at the beginning of every epoch.}
@@ -20,6 +25,26 @@ callback_lambda(on_epoch_begin = NULL, on_epoch_end = NULL,
 \item{on_train_begin}{called at the beginning of model training.}
 
 \item{on_train_end}{called at the end of model training.}
+
+\item{on_predict_batch_begin}{called at the beginning of a batch in predict methods.}
+
+\item{on_predict_batch_end}{called at the end of a batch in predict methods.}
+
+\item{on_predict_begin}{called at the beginning of prediction.}
+
+\item{on_predict_end}{called at the end of prediction.}
+
+\item{on_test_batch_begin}{called at the beginning of a batch in evaluate methods.
+Also called at the beginning of a validation batch in the fit methods,
+if validation data is provided.}
+
+\item{on_test_batch_end}{called at the end of a batch in evaluate methods.
+Also called at the end of a validation batch in the fit methods,
+if validation data is provided.}
+
+\item{on_test_begin}{called at the beginning of evaluation or validation.}
+
+\item{on_test_end}{called at the end of evaluation or validation.}
 }
 \description{
 This callback is constructed with anonymous functions that will be called at
@@ -27,8 +52,9 @@ the appropriate time. Note that the callbacks expects positional arguments,
 as:
 \itemize{
 \item \code{on_epoch_begin} and \code{on_epoch_end} expect two positional arguments: \code{epoch}, \code{logs}
-\item \code{on_batch_begin} and \code{on_batch_end} expect two positional arguments: \code{batch}, \code{logs}
-\item \code{on_train_begin} and \code{on_train_end} expect one positional argument: \code{logs}
+\item \code{on_batch_*}, \code{on_train_batch_*}, \code{on_predict_batch_*} and \code{on_test_batch_*}, expect
+two positional arguments: \code{batch}, \code{logs}
+\item \code{on_train_*}, \code{on_test_*} and \code{on_predict_*} expect one positional argument: \code{logs}
 }
 }
 \seealso{

--- a/man/callback_lambda.Rd
+++ b/man/callback_lambda.Rd
@@ -18,9 +18,13 @@ callback_lambda(on_epoch_begin = NULL, on_epoch_end = NULL,
 
 \item{on_epoch_end}{called at the end of every epoch.}
 
-\item{on_batch_begin}{called at the beginning of every batch.}
+\item{on_batch_begin}{called at the beginning of every training batch.}
 
-\item{on_batch_end}{called at the end of every batch.}
+\item{on_batch_end}{called at the end of every training batch.}
+
+\item{on_train_batch_begin}{called at the beginning of every batch.}
+
+\item{on_train_batch_end}{called at the end of every batch.}
 
 \item{on_train_begin}{called at the beginning of model training.}
 

--- a/man/evaluate.keras.engine.training.Model.Rd
+++ b/man/evaluate.keras.engine.training.Model.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{evaluate}{keras.engine.training.Model}(object, x = NULL,
   y = NULL, batch_size = NULL, verbose = 1, sample_weight = NULL,
-  steps = NULL, ...)
+  steps = NULL, callbacks = NULL, ...)
 }
 \arguments{
 \item{object}{Model object to evaluate}
@@ -36,6 +36,8 @@ sample. In this case you should make sure to specify
 
 \item{steps}{Total number of steps (batches of samples) before declaring the
 evaluation round finished. Ignored with the default value of \code{NULL}.}
+
+\item{callbacks}{List of callbacks to apply during evaluation.}
 
 \item{...}{Unused}
 }

--- a/man/evaluate_generator.Rd
+++ b/man/evaluate_generator.Rd
@@ -5,7 +5,7 @@
 \title{Evaluates the model on a data generator.}
 \usage{
 evaluate_generator(object, generator, steps, max_queue_size = 10,
-  workers = 1)
+  workers = 1, callbacks = NULL)
 }
 \arguments{
 \item{object}{Model object to evaluate}
@@ -22,6 +22,8 @@ targets, sample_weights)}
 \item{workers}{Maximum number of threads to use for parallel processing. Note that
 parallel processing will only be performed for native Keras generators (e.g.
 \code{flow_images_from_directory()}) as R based generators must run on the main thread.}
+
+\item{callbacks}{List of callbacks to apply during evaluation.}
 }
 \value{
 Named list of model test loss (or losses for models with multiple outputs)

--- a/man/predict.keras.engine.training.Model.Rd
+++ b/man/predict.keras.engine.training.Model.Rd
@@ -5,7 +5,8 @@
 \title{Generate predictions from a Keras model}
 \usage{
 \method{predict}{keras.engine.training.Model}(object, x,
-  batch_size = NULL, verbose = 0, steps = NULL, ...)
+  batch_size = NULL, verbose = 0, steps = NULL, callbacks = NULL,
+  ...)
 }
 \arguments{
 \item{object}{Keras model}
@@ -18,6 +19,8 @@
 
 \item{steps}{Total number of steps (batches of samples) before declaring the
 evaluation round finished. Ignored with the default value of \code{NULL}.}
+
+\item{callbacks}{List of callbacks to apply during prediction.}
 
 \item{...}{Unused}
 }

--- a/man/predict_generator.Rd
+++ b/man/predict_generator.Rd
@@ -5,7 +5,7 @@
 \title{Generates predictions for the input samples from a data generator.}
 \usage{
 predict_generator(object, generator, steps, max_queue_size = 10,
-  workers = 1, verbose = 0)
+  workers = 1, verbose = 0, callbacks = NULL)
 }
 \arguments{
 \item{object}{Keras model object}
@@ -23,6 +23,8 @@ parallel processing will only be performed for native Keras generators (e.g.
 \code{flow_images_from_directory()}) as R based generators must run on the main thread.}
 
 \item{verbose}{verbosity mode, 0 or 1.}
+
+\item{callbacks}{List of callbacks to apply during prediction.}
 }
 \value{
 Numpy array(s) of predictions.

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -102,9 +102,21 @@ test_succeeds("on predict callbacks", {
   model <- keras_model(input, output)
   
   cc <- CustomCallback$new()
-  out <- capture.output(
-    pred <- predict(model, x = matrix(1:10, ncol = 1), callbacks = cc)
-    )
   
-  expect_equal(out, c("PREDICT BEGINPREDICT END"))
+  warns <- capture_warning(
+    out <- capture.output(
+      pred <- predict(model, x = matrix(1:10, ncol = 1), callbacks = cc)
+    )  
+  )
+  
+  
+  if (get_keras_implementation() == "tensorflow" && 
+      tensorflow::tf_version() >= 2.0) {
+    expect_equal(out, c("PREDICT BEGINPREDICT END")) 
+    expect_null(warns)
+  } else {
+    expect_equal(out, character(0L))
+    expect_true(is.character(warns$message))
+  }
+  
 })

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -112,7 +112,7 @@ test_succeeds("on predict callbacks", {
   if (get_keras_implementation() == "tensorflow" && 
       tensorflow::tf_version() >= 2.0) {
     expect_equal(out, c("PREDICT BEGINPREDICT END")) 
-    expect_equal(warns, "")
+    expect_equal(warns, character())
   } else {
     expect_equal(out, "")
     expect_true(warns != "")

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -81,7 +81,29 @@ test_succeeds("custom callbacks", {
   
 })
 
-
-
-
-
+test_succeeds("on predict callbacks", {
+  
+  CustomCallback <- R6::R6Class(
+    "CustomCallback",
+    inherit = KerasCallback,
+    public = list(
+      on_predict_begin = function(logs) {
+        cat("PREDICT BEGIN\n")
+      },
+      on_predict_end = function(logs) {
+        cat("PREDICT END\n")
+      }
+    )
+  )
+  
+  input <- layer_input(shape = 1)
+  output <- layer_dense(input, 1)
+  model <- keras_model(input, output)
+  
+  cc <- CustomCallback$new()
+  out <- capture.output(
+    pred <- predict(model, x = matrix(1:10, ncol = 1), callbacks = cc)
+    )
+  
+  expect_equal(out, c("PREDICT_BEGIN", "PREDICT_END"))
+})

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -109,11 +109,6 @@ test_succeeds("on predict callbacks", {
     )  
   )
   
-  out <- capture.output(
-    pred <- predict(model, x = matrix(1:10, ncol = 1), callbacks = cc), 
-    type = c("output", "message", "warnings")
-  )
-  
   if (get_keras_implementation() == "tensorflow" && 
       tensorflow::tf_version() >= 2.0) {
     expect_equal(out, c("PREDICT BEGINPREDICT END")) 

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -102,21 +102,25 @@ test_succeeds("on predict callbacks", {
   model <- keras_model(input, output)
   
   cc <- CustomCallback$new()
-  
-  warns <- capture_warning(
-    out <- capture.output(
-      pred <- predict(model, x = matrix(1:10, ncol = 1), callbacks = cc)
+ 
+  warns <- capture_warnings(
+    out <- capture_output(
+      pred <- predict(model, x = matrix(1:10, ncol = 1), callbacks = cc), 
     )  
   )
   
+  out <- capture.output(
+    pred <- predict(model, x = matrix(1:10, ncol = 1), callbacks = cc), 
+    type = c("output", "message", "warnings")
+  )
   
   if (get_keras_implementation() == "tensorflow" && 
       tensorflow::tf_version() >= 2.0) {
     expect_equal(out, c("PREDICT BEGINPREDICT END")) 
-    expect_null(warns)
+    expect_equal(warns, "")
   } else {
-    expect_equal(out, character(0L))
-    expect_true(is.character(warns$message))
+    expect_equal(out, "")
+    expect_true(warns != "")
   }
   
 })

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -70,6 +70,7 @@ test_succeeds("custom callbacks", {
       on_batch_end = function(batch, logs = list()) {
         self$losses <- c(self$losses, logs[["loss"]])
       }
+      
     ))
   
   cc <- CustomCallback$new()
@@ -88,10 +89,10 @@ test_succeeds("on predict callbacks", {
     inherit = KerasCallback,
     public = list(
       on_predict_begin = function(logs) {
-        cat("PREDICT BEGIN\n")
+        cat("PREDICT BEGIN")
       },
       on_predict_end = function(logs) {
-        cat("PREDICT END\n")
+        cat("PREDICT END")
       }
     )
   )
@@ -105,5 +106,5 @@ test_succeeds("on predict callbacks", {
     pred <- predict(model, x = matrix(1:10, ncol = 1), callbacks = cc)
     )
   
-  expect_equal(out, c("PREDICT_BEGIN", "PREDICT_END"))
+  expect_equal(out, c("PREDICT BEGINPREDICT END"))
 })

--- a/vignettes/training_callbacks.Rmd
+++ b/vignettes/training_callbacks.Rmd
@@ -212,5 +212,45 @@ Custom callback objects can implement one or more of the following methods:
 
 :    Called at the end of training.
 
+`on_train_batch_begin` 
+
+:    Called at the beginning of every batch.
+
+`on_train_batch_end` 
+
+:    Called at the end of every batch.`
+
+`on_predict_batch_begin` 
+
+:    Called at the beginning of a batch in predict methods.
+
+`on_predict_batch_end` 
+
+:    Called at the end of a batch in predict methods.
+
+`on_predict_begin` 
+
+:    Called at the beginning of prediction.
+
+`on_predict_end` 
+
+:    Called at the end of prediction.
+
+`on_test_batch_begin` 
+
+:    Called at the beginning of a batch in evaluate methods. Also called at the beginning of a validation batch in the fit methods, if validation data is provided.
+     
+`on_test_batch_end` 
+
+:    Called at the end of a batch in evaluate methods. Also called at the end of a validation batch in the fit methods, if validation data is provided.
+
+`on_test_begin` 
+
+:    Called at the beginning of evaluation or validation.
+
+`on_test_end` 
+
+:    Called at the end of evaluation or validation.
+
 
 


### PR DESCRIPTION
Related to #712 .

It will take more time that I have imagined will and only work with tf-2.0 so I think it's better to wait until tf-1.13.1 is on CRAN.

- Dealing with tf versions lower than 2.0
- Add a  `callbacks` parameter to `evaluate`,  `predict_generator`, etc.
- Add tests for them
