### PR TITLE
Bugfix/main thread generator

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -1024,6 +1024,9 @@ is_main_thread_generator.keras_preprocessing.image.Iterator <- function(x) {
   }
 }
 
+is_main_thread_generator.keras_preprocessing.image.iterator.Iterator <- 
+  is_main_thread_generator.keras_preprocessing.image.Iterator
+
 is_tensorflow_dataset <- function(x) {
   inherits(x, "tensorflow.python.data.ops.dataset_ops.DatasetV2") ||
     inherits(x, "tensorflow.python.data.ops.dataset_ops.Dataset")

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -137,3 +137,29 @@ test_succeeds("R function can be used as custom generator with multiple inputs",
   model %>% fit_generator(generator, steps_per_epoch = 10)
 })
 
+test_succeeds("Can use a custom preprocessing function in image_data_generator", {
+  
+  img_gen <- image_data_generator(preprocessing_function = function(x) x/255)
+  
+  mnist <- dataset_mnist()
+  
+  flow <- flow_images_from_data(
+    array_reshape(mnist$train$x, dim = c(dim(mnist$train$x), 1)), 
+    to_categorical(mnist$train$y), 
+    img_gen
+  )
+  
+  model <- keras_model_sequential() %>% 
+    layer_flatten(input_shape = c(28,28, 1)) %>% 
+    layer_dense(units = 10, activation = "softmax")
+  
+  model %>% compile(loss = "categorical_crossentropy", optimizer = "adam", metrics = "accuracy")
+  
+  # test fitting the model
+  model %>% fit_generator(flow, steps_per_epoch = 5, epochs = 1)
+  preds <- predict_generator(model, flow, steps = 5)
+  eval <- evaluate_generator(model, flow, steps = 10)
+
+})
+
+


### PR DESCRIPTION
This fixes a bug that was causing `Error: C stack usage  567417110404 is too close to the limit` when using `preprocessing_function` inside `image_data_generator`. 

Example of what was failing:

```
library(keras)
img_gen <- image_data_generator(preprocessing_function = function(x) x/255)
  
  mnist <- dataset_mnist()
  
  flow <- flow_images_from_data(
    array_reshape(mnist$train$x, dim = c(dim(mnist$train$x), 1)), 
    to_categorical(mnist$train$y), 
    img_gen
  )
  
  model <- keras_model_sequential() %>% 
    layer_flatten(input_shape = c(28,28, 1)) %>% 
    layer_dense(units = 10, activation = "softmax")
  
  model %>% compile(loss = "categorical_crossentropy", optimizer = "adam", metrics = "accuracy")
  
  # test fitting the model
  model %>% fit_generator(flow, steps_per_epoch = 5, epochs = 1)
  preds <- predict_generator(model, flow, steps = 5)
  eval <- evaluate_generator(model, flow, steps = 10)
```