### PR TITLE
Allow passing dataframes to fit and etc.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 - Enabled calling Keras models with R arrays. (#806)
 
+- Allow passing `data.frames` as inputs to Keras models. (#822)
+
 ## Keras 2.2.4.1 (CRAN)
 
 - Use `tf.keras` as default implementation module.

--- a/R/utils.R
+++ b/R/utils.R
@@ -237,8 +237,7 @@ keras_array <- function(x, dtype = NULL) {
 
   # error for data frames
   if (is.data.frame(x)) {
-    stop("Data passed to Keras must be a vector, matrix, or array (you passed a ",
-         "data frame)", call. = FALSE)
+    x <- as.list(x)
   }
   
   # recurse for lists


### PR DESCRIPTION
Allowing data.frames will be useful to use the `layer_dense_features` without having to converto the df to a list. 