### PR TITLE
directly pass the dataset in 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_script:
   - sudo apt-get install python3
   - pip install --upgrade --ignore-installed --user travis virtualenv
   - R CMD INSTALL .
-  - R -e 'tensorflow::install_tensorflow(version = Sys.getenv("TENSORFLOW_VERSION"))'
+  - R -e 'keras::install_keras(tensorflow = Sys.getenv("TENSORFLOW_VERSION"))'
   - R -e 'tensorflow::tf_config()'
 
 notifications:

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@
 
 - Fixed bug when passing a TensorFlow dataset to `fit` within a `tf$distribute` scope. (#856)
 
+- `install_keras` will now install Keras dependencies (#856). It won't re-install TensorFlow if it's already installed.
+
 ## Keras 2.2.4.1 (CRAN)
 
 - Use `tf.keras` as default implementation module.

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@
 
 - Fixed bug when passing a fixed validation set to `fit_generator` (#837)
 
+- Fixed bug when passing a TensorFlow dataset to `fit` within a `tf$distribute` scope. (#856)
+
 ## Keras 2.2.4.1 (CRAN)
 
 - Use `tf.keras` as default implementation module.

--- a/R/install.R
+++ b/R/install.R
@@ -141,11 +141,22 @@ install_keras <- function(method = c("auto", "virtualenv", "conda"),
     }
   }
   
+  extra_packages <- unique(c(
+    paste0("keras", version), 
+    extra_packages,
+    "h5py", 
+    "pyyaml",
+    "requests",
+    "Pillow",
+    "scipy"
+  ))
+  
   # perform the install
   install_tensorflow(method = method,
                      conda = conda,
                      version = tensorflow,
-                     extra_packages = c(paste0("keras", version), extra_packages),
+                     extra_packages = extra_packages,
+                     pip_ignore_installed = FALSE,
                      ...)
 }
 

--- a/R/model.R
+++ b/R/model.R
@@ -1054,7 +1054,7 @@ resolve_tensorflow_dataset <- function(x) {
     }
     
     
-    if (tensorflow::tf_version() < "2.0") {
+    if (tensorflow::tf_version() < "1.14.0") {
       # yield iterators
       iter = x$make_one_shot_iterator()
       iter$get_next()  

--- a/tests/testthat/test-tfdatasets.R
+++ b/tests/testthat/test-tfdatasets.R
@@ -47,6 +47,9 @@ test_that("Error when specifying batch_size with tfdatasets", {
 
 test_succeeds("Works with tf$distribute", {
   
+  if (tensorflow::tf_version() < "1.14.0")
+    skip("tf$distribute is not available in TF prior to v1.14")
+  
   strategy <- tensorflow::tf$distribute$MirroredStrategy()
   
   with (strategy$scope(), {

--- a/tests/testthat/test-tfdatasets.R
+++ b/tests/testthat/test-tfdatasets.R
@@ -43,3 +43,27 @@ test_that("Error when specifying batch_size with tfdatasets", {
   )
   
 })
+
+
+test_succeeds("Works with tf$distribute", {
+  
+  strategy <- tensorflow::tf$distribute$MirroredStrategy()
+  
+  with (strategy$scope(), {
+    
+    model <- keras_model_sequential() %>% 
+      layer_dense(units = 1, input_shape = 1)
+    model %>% compile(loss='mse', optimizer='sgd')
+    
+  })
+  
+  dataset <- tfdatasets::tensors_dataset(reticulate::tuple(list(1), list(1))) %>% 
+    tfdatasets::dataset_repeat(100) %>% 
+    tfdatasets::dataset_shuffle(buffer_size = 100) %>% 
+    tfdatasets::dataset_batch(10)
+  
+  model %>% 
+    fit(dataset, epochs = 10, verbose = 0)
+  
+})
+


### PR DESCRIPTION
Make `fit` compatible with tfdatasets with 1.14 when using `tf.distribute`. fixes #855 