### PR TITLE
check if the signature can get the training argument.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_script:
   - sudo apt-get install python3
   - pip install --upgrade --ignore-installed --user travis virtualenv
   - R CMD INSTALL .
-  - R -e 'tensorflow::install_tensorflow(version = Sys.getenv("TENSORFLOW_VERSION"))'
+  - R -e 'keras::install_keras(tensorflow = Sys.getenv("TENSORFLOW_VERSION"))'
   - R -e 'tensorflow::tf_config()'
 
 notifications:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,8 @@ Suggests:
     rmarkdown,
     tfdatasets,
     jpeg
+Remotes:
+    rstudio/reticulate
 SystemRequirements: Keras >= 2.0 (https://keras.io)
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1

--- a/R/model-custom.R
+++ b/R/model-custom.R
@@ -27,7 +27,18 @@ keras_model_custom <- function(model_fn, name = NULL) {
   r_model_call <- model_fn(model)
   
   # set the _r_call for delegation
-  model$`_r_call` <- reticulate::py_func(r_model_call)
+  # we search for training ot ... in the function signature, otherwise
+  # we need to remove it from the call.
+  model$`_r_call` <- function(...) {
+    
+    args <- list(...)
+    
+    if (!any(c("...", "training") %in% names(formals(r_model_call))))
+      args[["training"]] <- NULL
+    
+    do.call(r_model_call, args) 
+    
+  }
   
   # return model
   model


### PR DESCRIPTION
@skeydan In tf-nightly the subclassed models are [failing with](https://travis-ci.org/rstudio/keras/jobs/566656786#L3391):

```
3391`force(expr)` threw an error.
3392Message: TypeError: in converted code:
3393
3394    /home/travis/build/rstudio/keras/keras.Rcheck/keras/python/kerastools/model.py:19 call  *
3395        return self._r_call(inputs, mask, **kwargs)
3396
3397    TypeError: fn() got an unexpected keyword argument 'training'
```

This is because the `call` method can optionally have a `training` argument which our model doesn't expect.

(This also depends on dev reticulate)

The following fixes the problem, but seems somewhat dangerous.

Another possible fix is to ask people to return functions with a `training` argument. Eg:

```
keras_model_custom(name = name, function(self) {
    
    # create layers we'll need for the call (this code executes once)
    self$dense1 <- layer_dense(units = 32, activation = "relu")
    self$dense2 <- layer_dense(units = num_classes, activation = "softmax")
    if (use_dp)
      self$dp <- layer_dropout(rate = 0.5)
    if (use_bn)
      self$bn <- layer_batch_normalization(axis = -1)
    
    # implement call (this code executes during training & inference)
    function(inputs, mask = NULL, training = FALSE) {
      x <- self$dense1(inputs)
      if (use_dp)
        x <- self$dp(x)
      if (use_bn)
        x <- self$bn(x)
      self$dense2(x)
    }
  })
```

What do you think?