### PR TITLE
Call normalizePath to handle paths on windows.

### DIFF
--- a/R/layers-core.R
+++ b/R/layers-core.R
@@ -417,7 +417,7 @@ normalize_path <- function(path) {
   if (is.null(path))
     NULL
   else
-    path.expand(path)
+    normalizePath(path.expand(path), mustWork = FALSE)
 }
 
 # Helper function to coerce shape arguments to tuple


### PR DESCRIPTION
This fixes https://github.com/rstudio/tfruns/issues/43