### PR TITLE
After loading an image, convert the array of numeric to array of int

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -523,10 +523,11 @@ image_load <- function(path, grayscale = FALSE, target_size = NULL,
 #'
 #' @export
 image_to_array <- function(img, data_format = c("channels_last", "channels_first")) {
-  keras$preprocessing$image$img_to_array(
+  res_arr <- keras$preprocessing$image$img_to_array(
     img = img,
     data_format = match.arg(data_format)
   )
+  apply(res_arr, 1:3, as.integer)
 }
 
 #' @rdname image_to_array


### PR DESCRIPTION
Hi @dfalbel ,
this is what I was talking about, [as far as I have seen](https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing/image/img_to_array), it is not specified if the returned array is numeric for any reason.
It would need some more research in order to accept this PR.


`image_to_array` function is returning an array of numerics, so it weighs much more than an array of integers.

As far as I know, an image converted into an array would be an RGB array of integers \[0; 255\] . I have been trying with different parameters of the `image_load` and `image_to_array` functions.

``` r
library("keras")
library("magrittr")

setwd("~/mytmp/")
download.file(
  "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/google/223/mate-drink_1f9c9.png",
  "img.png"
)
act_img <- "img.png"

res <- act_img %>%
  image_load() %>%
  image_to_array()

dim(res)
```

    ## [1] 160 160   3

``` r
class(res[1,1,])
```

    ## [1] "numeric"

``` r
int_res <- apply(res, 1:3, as.integer)
all(res == int_res)
```

    ## [1] TRUE

``` r
object.size(res)
```

    ## 614624 bytes

``` r
object.size(int_res)
```

    ## 307424 bytes
