### PR TITLE
Call model with additional args

### DIFF
--- a/R/layers-core.R
+++ b/R/layers-core.R
@@ -518,36 +518,38 @@ create_layer <- function(layer_class, object, args = list()) {
 
 # Helper function to compose a layer with an object of type Model or Layer
 
-compose_layer <- function(object, layer) {
+compose_layer <- function(object, layer, ...) {
   UseMethod("compose_layer")  
 }
 
-compose_layer.default <- function(object, layer) {
+compose_layer.default <- function(object, layer, ...) {
   stop_with_invalid_layer()
 }
 
-compose_layer.keras.models.Sequential <- function(object, layer) {
+compose_layer.keras.models.Sequential <- function(object, layer, ...) {
+  if(length(list(...)) > 0) warning("arguments passed via ellipsis will be ignored")
+  
   object$add(layer)
   object
 }
 
 compose_layer.keras.engine.sequential.Sequential <- compose_layer.keras.models.Sequential
 
-compose_layer.python.builtin.object <- function(object, layer) {
+compose_layer.python.builtin.object <- function(object, layer, ...) {
   if (is.function(layer))
-    layer(object)
+    layer(object, ...)
   else
     stop_with_invalid_layer()
 }
 
-compose_layer.list <- function(object, layer) {
-  layer(object)
+compose_layer.list <- function(object, layer, ...) {
+  layer(object, ...)
 }
 
-compose_layer.numeric <- function(object, layer) {
+compose_layer.numeric <- function(object, layer, ...) {
   if (!tensorflow::tf_version() >= "1.14") stop_with_invalid_layer()
   if (is.function(layer))
-    layer(object)
+    layer(object, ...)
   else
     stop_with_invalid_layer()
 }

--- a/R/model.R
+++ b/R/model.R
@@ -187,8 +187,8 @@ multi_gpu_model <- function(model, gpus = NULL, cpu_merge = TRUE, cpu_relocation
 #' @importFrom reticulate py_to_r_wrapper
 #' @export
 py_to_r_wrapper.keras.engine.training.Model <- function(x) {
-  function(object) {
-    compose_layer(object, x)
+  function(object, ...) {
+    compose_layer(object, x, ...)
   }
 }
 

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -105,6 +105,17 @@ test_succeeds("can call model with R objects", {
   model(l)
 })
 
+test_succeeds("can call a model with additional arguments", {
+  
+  if (tensorflow::tf_version() < "2.0") skip("needs TF > 2")
+  
+  model <- keras_model_sequential() %>% 
+    layer_dropout(rate = 0.99999999)
+  expect_equivalent(as.numeric(model(1, training = TRUE)), 0)
+  expect_equivalent(as.numeric(model(1, training = FALSE)), 1)
+  
+})
+
 
 
 


### PR DESCRIPTION
This PR enables passing additional arguments when calling a model. This enable something like:

```
model <- keras_model_sequential() %>% 
  layer_dropout(rate = 0.99999999)
model(1, training = TRUE)
model(1, training = FALSE)
```