### PR TITLE
ENH: Added check for batch_size when in flow, fixing https://github.c…

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -763,6 +763,7 @@ flow_images_from_data <- function(
     save_prefix = save_prefix,
     save_format = save_format
   )
+  stopifnot(args$batch_size > 0)
   
   if (keras_version() >= "2.1.5")
     args$subset <- subset
@@ -833,6 +834,7 @@ flow_images_from_directory <- function(
     save_format = save_format,
     follow_links = follow_links
   )
+  stopifnot(args$batch_size > 0)
   
   if (keras_version() >= "2.1.2")
     args$interpolation <- interpolation
@@ -931,6 +933,7 @@ flow_images_from_dataframe <- function(
     save_format = save_format,
     drop_duplicates = drop_duplicates
   )
+  stopifnot(args$batch_size > 0)
   
   if (keras_version() >= "2.1.2") 
     args$interpolation <- interpolation


### PR DESCRIPTION
Fixes https://github.com/rstudio/keras/issues/912, with a simple check to make sure `batch_size` is positive, otherwise getting a division of zero error on Python, which I'm not sure if you can break from.