### PR TITLE
Using tf.keras instead of tf.python.keras

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -272,7 +272,8 @@ inception_resnet_v2_preprocess_input <- function(x) {
 imagenet_decode_predictions <- function(preds, top = 5) {
   
   # decode predictions
-  decoded <- keras$applications$imagenet_utils$decode_predictions(
+  # we use the vgg16 function which is the same as imagenet_utils
+  decoded <- keras$applications$vgg16$decode_predictions(
     preds = preds,
     top = as.integer(top)
   )
@@ -308,13 +309,14 @@ imagenet_decode_predictions <- function(preds, top = 5) {
 imagenet_preprocess_input <- function(x, data_format = NULL, mode = "caffe") {
   args <- list(
     x = x,
-    preprocessor = keras$applications$imagenet_utils$preprocess_input
+    # we use the vgg16 function which is the same as imagenet_utils
+    preprocessor = keras$applications$vgg16$preprocess_input
   )
   if (keras_version() >= "2.0.9") {
     args$data_format <- data_format
     args$mode <- mode
   }
-  preprocess_input(x, keras$applications$imagenet_utils$preprocess_input)
+  do.call(preprocess_input, args)
 }
 
 

--- a/R/initializers.R
+++ b/R/initializers.R
@@ -212,7 +212,7 @@ initializer_lecun_normal <- function(seed = NULL) {
 #' 
 #' @export
 initializer_glorot_normal <- function(seed = NULL) {
-  keras$initializers$GlorotNormal(
+  keras$initializers$glorot_normal(
     seed = as_nullable_integer(seed)
   )
 }
@@ -234,7 +234,7 @@ initializer_glorot_normal <- function(seed = NULL) {
 #' 
 #' @export
 initializer_glorot_uniform <- function(seed = NULL) {
-  keras$initializers$GlorotUniform(
+  keras$initializers$glorot_uniform(
     seed = as_nullable_integer(seed)
   )
 }

--- a/R/initializers.R
+++ b/R/initializers.R
@@ -6,10 +6,7 @@
 #' 
 #' @export
 initializer_zeros <- function() {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$ZerosV2()
-  else 
-    keras$initializers$Zeros()
+  keras$initializers$Zeros()
 }
 
 #' Initializer that generates tensors initialized to 1.
@@ -18,10 +15,7 @@ initializer_zeros <- function() {
 #' 
 #' @export
 initializer_ones <- function() {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$OnesV2()
-  else
-    keras$initializers$Ones()
+  keras$initializers$Ones()
 }
 
 #' Initializer that generates tensors initialized to a constant value.
@@ -32,14 +26,9 @@ initializer_ones <- function() {
 #' 
 #' @export
 initializer_constant <- function(value = 0) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$ConstantV2(
-      value = value
-    )
-  else
-    keras$initializers$Constant(
-      value = value
-    )
+  keras$initializers$Constant(
+    value = value
+  )
 }
 
 
@@ -53,18 +42,11 @@ initializer_constant <- function(value = 0) {
 #' 
 #' @export
 initializer_random_normal <- function(mean = 0.0, stddev = 0.05, seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$RandomNormalV2(
-      mean = mean,
-      stddev = stddev,
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$RandomNormal(
-      mean = mean,
-      stddev = stddev,
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$RandomNormal(
+    mean = mean,
+    stddev = stddev,
+    seed = as_nullable_integer(seed)
+  )
 }
 
 #' Initializer that generates tensors with a uniform distribution.
@@ -78,18 +60,11 @@ initializer_random_normal <- function(mean = 0.0, stddev = 0.05, seed = NULL) {
 #' 
 #' @export
 initializer_random_uniform <- function(minval = -0.05, maxval = 0.05, seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$RandomUniformV2(
-      minval = minval,
-      maxval = maxval,
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$RandomUniform(
-      minval = minval,
-      maxval = maxval,
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$RandomUniform(
+    minval = minval,
+    maxval = maxval,
+    seed = as_nullable_integer(seed)
+  )
 }
 
 
@@ -106,18 +81,11 @@ initializer_random_uniform <- function(minval = -0.05, maxval = 0.05, seed = NUL
 #' 
 #' @export
 initializer_truncated_normal <- function(mean = 0.0, stddev = 0.05, seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$TruncatedNormalV2(
-      mean = mean,
-      stddev = stddev,
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$TruncatedNormal(
-      mean = mean,
-      stddev = stddev,
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$TruncatedNormal(
+    mean = mean,
+    stddev = stddev,
+    seed = as_nullable_integer(seed)
+  )
 }
 
 #' Initializer capable of adapting its scale to the shape of weights.
@@ -152,7 +120,7 @@ initializer_variance_scaling <- function(scale = 1.0, mode = c("fan_in", "fan_ou
     if (distribution == "normal")
       distribution <- "untruncated_normal"
     
-    keras$initializers$VarianceScalingV2(
+    keras$initializers$VarianceScaling(
       scale = scale,
       mode = match.arg(mode),
       distribution = distribution,
@@ -183,16 +151,10 @@ initializer_variance_scaling <- function(scale = 1.0, mode = c("fan_in", "fan_ou
 #' 
 #' @export
 initializer_orthogonal <- function(gain = 1.0, seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$OrthogonalV2(
-      gain = gain,
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$Orthogonal(
-      gain = gain,
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$Orthogonal(
+    gain = gain,
+    seed = as_nullable_integer(seed)
+  )
 }
 
 
@@ -206,14 +168,9 @@ initializer_orthogonal <- function(gain = 1.0, seed = NULL) {
 #' 
 #' @export
 initializer_identity <- function(gain = 1.0) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$IdentityV2(
-      gain = gain
-    )
-  else
-    keras$initializers$Identity(
-      gain = gain
-    )
+  keras$initializers$Identity(
+    gain = gain
+  )
 }
 
 #' LeCun normal initializer.
@@ -232,14 +189,9 @@ initializer_identity <- function(gain = 1.0) {
 #'
 #' @export
 initializer_lecun_normal <- function(seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$lecun_normalV2(
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$lecun_normal(
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$lecun_normal(
+    seed = as_nullable_integer(seed)
+  )
 }
 
 
@@ -260,14 +212,9 @@ initializer_lecun_normal <- function(seed = NULL) {
 #' 
 #' @export
 initializer_glorot_normal <- function(seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$GlorotNormalV2(
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$GlorotNormal(
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$GlorotNormal(
+    seed = as_nullable_integer(seed)
+  )
 }
 
 
@@ -287,14 +234,9 @@ initializer_glorot_normal <- function(seed = NULL) {
 #' 
 #' @export
 initializer_glorot_uniform <- function(seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$GlorotUniformV2(
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$GlorotUniform(
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$GlorotUniform(
+    seed = as_nullable_integer(seed)
+  )
 }
 
 
@@ -312,14 +254,9 @@ initializer_glorot_uniform <- function(seed = NULL) {
 #'      
 #' @export
 initializer_he_normal <- function(seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$he_normalV2(
-      seed = seed
-    )
-  else
-    keras$initializers$he_normal(
-      seed = seed
-    )
+  keras$initializers$he_normal(
+    seed = seed
+  )
 }
 
 #' He uniform variance scaling initializer.
@@ -336,14 +273,9 @@ initializer_he_normal <- function(seed = NULL) {
 #'   
 #' @export
 initializer_he_uniform <- function(seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$he_uniformV2(
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$he_uniform(
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$he_uniform(
+    seed = as_nullable_integer(seed)
+  )
 }
 
 #' LeCun uniform initializer.
@@ -360,13 +292,8 @@ initializer_he_uniform <- function(seed = NULL) {
 #'   
 #' @export
 initializer_lecun_uniform <- function(seed = NULL) {
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= "2.0")
-    keras$initializers$lecun_uniformV2(
-      seed = as_nullable_integer(seed)
-    )
-  else
-    keras$initializers$lecun_uniform(
-      seed = as_nullable_integer(seed)
-    )
+  keras$initializers$lecun_uniform(
+    seed = as_nullable_integer(seed)
+  )
 }
 

--- a/R/layers-features.R
+++ b/R/layers-features.R
@@ -24,7 +24,7 @@ layer_dense_features <- function(object, feature_columns, name = NULL,
   # feature_columns must be unamed otherwise they are converted to a dict
   names(feature_columns) <- NULL
   
-  create_layer(keras$api$`_v2`$keras$layers$DenseFeatures, object, list(
+  create_layer(keras$layers$DenseFeatures, object, list(
     feature_columns = feature_columns, 
     name = name,
     trainable = trainable,

--- a/R/optimizers.R
+++ b/R/optimizers.R
@@ -33,10 +33,7 @@ optimizer_sgd <- function(lr = 0.01, momentum = 0.0, decay = 0.0, nesterov = FAL
   )
   args$clipnorm <- clipnorm
   args$clipvalue <- clipvalue
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0)
-    do.call(keras$optimizers$gradient_descent_v2$SGD, args)
-  else
-    do.call(keras$optimizers$SGD, args)
+  do.call(keras$optimizers$SGD, args)
 }
 
 #' RMSProp optimizer
@@ -65,10 +62,7 @@ optimizer_rmsprop <- function(lr = 0.001, rho = 0.9, epsilon = NULL, decay = 0.0
   )
   args$clipnorm <- clipnorm
   args$clipvalue <- clipvalue
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0)
-    do.call(keras$optimizers$rmsprop_v2$RMSprop, args)
-  else
-    do.call(keras$optimizers$RMSprop, args)
+  do.call(keras$optimizers$RMSprop, args)
 }
 
 
@@ -97,10 +91,7 @@ optimizer_adagrad <- function(lr = 0.01, epsilon = NULL, decay = 0.0,
   )
   args$clipnorm <- clipnorm
   args$clipvalue <- clipvalue
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0)
-    do.call(keras$optimizers$adagrad_v2$Adagrad, args)
-  else
-    do.call(keras$optimizers$Adagrad, args)
+  do.call(keras$optimizers$Adagrad, args)
 }
 
 #' Adadelta optimizer.
@@ -128,10 +119,7 @@ optimizer_adadelta <- function(lr = 1.0, rho = 0.95, epsilon = NULL, decay = 0.0
   )
   args$clipnorm <- clipnorm
   args$clipvalue <- clipvalue
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0)
-    do.call(keras$optimizers$adadelta_v2$Adadelta, args)
-  else
-    do.call(keras$optimizers$Adadelta, args)
+  do.call(keras$optimizers$Adadelta, args)
 }
 
 #' Adam optimizer
@@ -173,10 +161,7 @@ optimizer_adam <- function(lr = 0.001, beta_1 = 0.9, beta_2 = 0.999, epsilon = N
   if (keras_version() >= "2.1.3")
     args$amsgrad <- amsgrad
   
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0)
-    do.call(keras$optimizers$adam_v2$Adam, args)
-  else
-    do.call(keras$optimizers$Adam, args)
+  do.call(keras$optimizers$Adam, args)
 }
 
 #' Adamax optimizer
@@ -203,10 +188,7 @@ optimizer_adamax <- function(lr = 0.002, beta_1 = 0.9, beta_2 = 0.999, epsilon =
   args$clipnorm <- clipnorm
   args$clipvalue <- clipvalue
   
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0)
-    do.call(keras$optimizers$adamax_v2$Adamax, args)
-  else
-    do.call(keras$optimizers$Adamax, args)
+  do.call(keras$optimizers$Adamax, args)
 }
 
 #' Nesterov Adam optimizer
@@ -241,10 +223,7 @@ optimizer_nadam <- function(lr = 0.002, beta_1 = 0.9, beta_2 = 0.999, epsilon = 
   args$clipnorm <- clipnorm
   args$clipvalue <- clipvalue
   
-  if (get_keras_implementation() == "tensorflow" && tensorflow::tf_version() >= 2.0)
-    do.call(keras$optimizers$nadam_v2$Nadam, args)
-  else
-    do.call(keras$optimizers$Nadam, args)
+  do.call(keras$optimizers$Nadam, args)
 }
 
 resolve_epsilon <- function(epsilon) {

--- a/R/package.R
+++ b/R/package.R
@@ -133,7 +133,13 @@ keras <- NULL
   
   # register class filter to alias classes to 'keras'
   reticulate::register_class_filter(function(classes) {
-    sub(paste0("^", resolve_implementation_module()), "keras", classes)
+    
+    module <- resolve_implementation_module()
+    
+    if (identical(module, "tensorflow.keras"))
+      module <- "tensorflow.python.keras"
+      
+    sub(paste0("^", module), "keras", classes)
   })
   
   # tensorflow use_session hooks
@@ -153,7 +159,7 @@ resolve_implementation_module <- function() {
   
   # set the implementation module
   if (identical(implementation, "tensorflow"))
-    implementation_module <- "tensorflow.python.keras"
+    implementation_module <- "tensorflow.keras"
   else
     implementation_module <- implementation
   

--- a/tests/testthat/test-layers.R
+++ b/tests/testthat/test-layers.R
@@ -526,7 +526,7 @@ test_call_succeeds("layer_dense_features", required_version = "2.1.3", {
 
 test_succeeds("Can serialize a model that contains dense_features", {
   
-  if (tensorflow::tf_version() <= "2.0")
+  if (tensorflow::tf_version() < "2.0")
     skip("TensorFlow 2.0 is required.")
   
   fc <- list(tensorflow::tf$feature_column$numeric_column("mpg"))

--- a/tests/testthat/test-preprocessing.R
+++ b/tests/testthat/test-preprocessing.R
@@ -54,7 +54,9 @@ test_succeeds("image can be preprocessed", {
     img <- image_load("digit.jpeg")
     img_arr <- image_to_array(img)
     img_arr <- array_reshape(img_arr, c(1, dim(img_arr)))
-    img_arr <- imagenet_preprocess_input(img_arr)
+    img_arr1 <- imagenet_preprocess_input(img_arr)
+    img_arr2 <- preprocess_input(img_arr, tensorflow::tf$python$keras$applications$imagenet_utils$preprocess_input)
+    expect_equal(img_arr1, img_arr2)
   }
 })
 

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -5,14 +5,9 @@ skip_if_no_keras <- function(required_version = NULL) {
     skip("required keras version not available for testing")
 }
 
+py_capture_output <- reticulate::import("IPython")$utils$capture$capture_output
 
 test_succeeds <- function(desc, expr, required_version = NULL) {
-  
-  py_capture_output <- NULL
-  if (reticulate::py_module_available("IPython")) {
-    IPython <- reticulate::import("IPython")
-    py_capture_output <- IPython$utils$capture$capture_output
-  }
   
   invisible(
     capture.output({


### PR DESCRIPTION
See https://stackoverflow.com/questions/58279628/what-is-the-difference-between-tf-keras-and-tf-python-keras/58279629#58279629

@kevinykuo We were already using correct optmizerV2 for instance, but this will be important since they are changing a lot the API in `tf.python.keras` recently.