### PR TITLE
get_vocabulary performance

### DIFF
--- a/R/layer-text_vectorization.R
+++ b/R/layer-text_vectorization.R
@@ -93,7 +93,9 @@ layer_text_vectorization <- function(object, max_tokens = NULL, standardize = "l
 #' @seealso [set_vocabulary()]
 #' @export
 get_vocabulary <- function(object) {
-  object$get_vocabulary()
+  python_path <- system.file("python", package = "keras")
+  tools <- import_from_path("kerastools", path = python_path)
+  tools$get_vocabulary$get_vocabulary(object)
 }
 
 #' Sets vocabulary (and optionally document frequency) data for the layer

--- a/inst/python/kerastools/get_vocabulary.py
+++ b/inst/python/kerastools/get_vocabulary.py
@@ -1,0 +1,5 @@
+
+def get_vocabulary (layer):
+  vocab = layer.get_vocabulary()
+  return([x.decode("UTF-8") for x in vocab])
+


### PR DESCRIPTION
`get_vocabulary` is very slow in R because it returns byte strings which are not directly handled by reticulate. 

With this PR we convert the byte strings  to UTF8 using `.decode` before passing to R, making it much faster.