### PR TITLE
Avoid progbar workaround in 2.3

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -110,7 +110,7 @@ keras <- NULL
       check_implementation_version()
       
       # patch progress bar for interactive/tty sessions
-      if ((interactive() || isatty(stdout())) && keras_version() >= "2.0.9") {
+      if ((interactive() || isatty(stdout())) && keras_version() >= "2.0.9" && keras_version() < "2.3.0") {
         python_path <- system.file("python", package = "keras")
         tools <- import_from_path("kerastools", path = python_path)
         tools$progbar$apply_patch()


### PR DESCRIPTION
When using TF 2.2:

```r
tensorflow::install_tensorflow(version = "2.1")
tfds::install_tfds()
tensorflow::tf_version()
```

```r
library(tensorflow)
library(keras)

library(tfdatasets)
library(tfds)

BUFFER_SIZE <- 10000
BATCH_SIZE <- 64

mnist <- tfds_load("mnist")

train_dataset <- mnist$train %>% 
  dataset_map(function(record) {
    record$image <- tf$cast(record$image, tf$float32) / 255
    record}) %>%
  dataset_cache() %>%
  dataset_shuffle(BUFFER_SIZE) %>% 
  dataset_batch(BATCH_SIZE) %>% 
  dataset_map(unname)
  
model <- keras_model_sequential(list(
    layer_conv_2d(
        filters = 32,
        kernel_size = 3,
        activation = 'relu',
        input_shape = c(28, 28, 1)
    ),
    layer_max_pooling_2d(),
    layer_flatten(),
    layer_dense(units = 64, activation = 'relu'),
    layer_dense(units = 10, activation = 'softmax')))
   
model$compile(
  loss = 'sparse_categorical_crossentropy',
  optimizer = 'adam',
  metrics = 'accuracy')
```
```
Error in py_get_attr_impl(x, name, silent) : 
  AttributeError: module 'kerastools' has no attribute 'progbar'
```