### PR TITLE
Fixes metric callbacks with TF 2.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-16.04']
-        tf: ['1.14.0', '1.15.2', '2.0.1', '2.1.0', 'nightly']
+        tf: ['1.14.0', '1.15.2', '2.0.1', '2.1.0', , '2.2-rc3', 'nightly']
         include:
           - os: ubuntu-16.04
             cran: https://demo.rstudiopm.com/all/__linux__/xenial/latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-16.04']
-        tf: ['1.14.0', '1.15.2', '2.0.1', '2.1.0', , '2.2-rc3', 'nightly']
+        tf: ['1.14.0', '1.15.2', '2.0.1', '2.1.0', '2.2-rc3', 'nightly']
         include:
           - os: ubuntu-16.04
             cran: https://demo.rstudiopm.com/all/__linux__/xenial/latest

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## Development Version
 
 - Added `layer_attention` (#1000) by @atroiano.
+- Fixed issue regarding the KerasMetricsCallback with TF v2.2 (#1020)
 
 ## Keras 2.2.5.0 (CRAN)
 

--- a/R/applications.R
+++ b/R/applications.R
@@ -314,7 +314,9 @@ imagenet_preprocess_input <- function(x, data_format = NULL, mode = "caffe") {
   )
   if (keras_version() >= "2.0.9") {
     args$data_format <- data_format
-    args$mode <- mode
+    # no longer exists in 2.2
+    if (tensorflow::tf_version() <= "2.1")
+      args$mode <- mode
   }
   do.call(preprocess_input, args)
 }

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -627,7 +627,12 @@ normalize_callbacks_with_metrics <- function(view_metrics, callbacks) {
     callbacks <- list(callbacks)
   
   # always include the metrics callback
-  callbacks <- append(callbacks, KerasMetricsCallback$new(view_metrics))  
+  if (tensorflow::tf_version() >= "2.2.0")
+    metrics_callback <- KerasMetricsCallbackV2$new(view_metrics)
+  else
+    metrics_callback <- KerasMetricsCallback$new(view_metrics)
+  
+  callbacks <- append(callbacks, metrics_callback)  
  
   normalize_callbacks(callbacks) 
 }
@@ -717,11 +722,11 @@ normalize_callbacks <- function(callbacks) {
       )
       
       # on_batch_* -> on_train_batch_*
-      if (!identical(callback$on_batch_begin, empty_fun)) {
+      if (!all.equal(callback$on_batch_begin, empty_fun)) {
         args$r_on_train_batch_begin <- callback$on_batch_begin
       }
       
-      if (!identical(callback$on_batch_end, empty_fun)) {
+      if (!all.equal(callback$on_batch_end, empty_fun)) {
         args$r_on_train_batch_end <- callback$on_batch_end
       }
       

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -722,11 +722,11 @@ normalize_callbacks <- function(callbacks) {
       )
       
       # on_batch_* -> on_train_batch_*
-      if (!all.equal(callback$on_batch_begin, empty_fun)) {
+      if (!isTRUE(all.equal(callback$on_batch_begin, empty_fun))) {
         args$r_on_train_batch_begin <- callback$on_batch_begin
       }
       
-      if (!all.equal(callback$on_batch_end, empty_fun)) {
+      if (!isTRUE(all.equal(callback$on_batch_end, empty_fun))) {
         args$r_on_train_batch_end <- callback$on_batch_end
       }
       

--- a/R/install.R
+++ b/R/install.R
@@ -145,7 +145,7 @@ install_keras <- function(method = c("auto", "virtualenv", "conda"),
     paste0("keras", version), 
     extra_packages,
     "h5py", 
-    "pyyaml",
+    "pyyaml==3.12",
     "requests",
     "Pillow",
     "scipy"

--- a/R/metrics-callback.R
+++ b/R/metrics-callback.R
@@ -1,7 +1,6 @@
-
-
-KerasMetricsCallback <- R6::R6Class("KerasMetricsCallback",
-                                  
+KerasMetricsCallback <- R6::R6Class(
+  "KerasMetricsCallback",
+  
   inherit = KerasCallback,
   
   public = list(
@@ -87,7 +86,7 @@ KerasMetricsCallback <- R6::R6Class("KerasMetricsCallback",
     
     # convert keras history to metrics data frame suitable for plotting
     as_metrics_df = function(history) {
-    
+      
       # create metrics data frame
       df <- as.data.frame(history$metrics)
       
@@ -128,8 +127,146 @@ KerasMetricsCallback <- R6::R6Class("KerasMetricsCallback",
       }, error = function(e) {
         warning("Unable to log model info: ", e$message, call. = FALSE)
       })
-     
+      
     }
   )
 )
+
+KerasMetricsCallbackV2 <- R6::R6Class(
+  "KerasMetricsCallbackV2",
+  
+  inherit = KerasCallback,
+  
+  public = list(
+    
+    # instance data
+    metrics = list(),
+    metrics_viewer = NULL,
+    view_metrics = FALSE,
+    
+    initialize = function(view_metrics = FALSE) {
+      self$view_metrics <- view_metrics
+    },
+    
+    on_train_begin = function(logs = NULL) {
+      if (tfruns::is_run_active()) {
+        self$write_params(self$params)
+        self$write_model_info(self$model)
+      }
+    },
+    
+    on_epoch_end = function(epoch, logs = NULL) {
+      
+      if (epoch == 0) {
+        
+        metric_names <- names(logs)
+        for (metric in metric_names)
+          self$metrics[[metric]] <- numeric()  
+        
+        sleep <- 0.5
+      } else {
+        
+        sleep <- 0.1
+        
+      }
+
+      # handle metrics
+      self$on_metrics(logs, sleep)
+      
+    },
+    
+    on_metrics = function(logs, sleep) {
+      
+      # record metrics
+      for (metric in names(self$metrics)) {
+        # guard against metrics not yet available by using NA 
+        # when a named metrics isn't passed in 'logs'
+        value <- logs[[metric]]
+        if (is.null(value))
+          value <- NA
+        else
+          value <- mean(value)
+        
+        self$metrics[[metric]] <- c(self$metrics[[metric]], value)
+      }
+      
+      # create history object and convert to metrics data frame
+      
+      history <- keras_training_history(self$params, self$metrics)
+      metrics <- self$as_metrics_df(history)
+      
+      # view metrics if requested
+      if (self$view_metrics) {
+        
+        # create the metrics_viewer or update if we already have one
+        if (is.null(self$metrics_viewer)) {
+          self$metrics_viewer <- tfruns::view_run_metrics(metrics)
+        } else {
+          tfruns::update_run_metrics(self$metrics_viewer, metrics)
+        }
+        
+        # pump events
+        Sys.sleep(sleep)
+      }
+      
+      # record metrics
+      tfruns::write_run_metadata("metrics", metrics)
+      
+    },
+    
+    # convert keras history to metrics data frame suitable for plotting
+    as_metrics_df = function(history) {
+      # create metrics data frame
+      df <- as.data.frame(history$metrics)
+      
+      # pad to epochs if necessary
+      pad <- history$params$epochs - nrow(df)
+      pad_data <- list()
+      
+      if (tensorflow::tf_version() < "2.2")
+        metric_names <- history$params$metrics
+      else
+        metric_names <- names(history$metrics)
+        
+      for (metric in metric_names)
+        pad_data[[metric]] <- rep_len(NA, pad)
+      
+      df <- rbind(df, pad_data)
+      
+      # return df
+      df
+    },
+    
+    write_params = function(params) {
+      properties <- list()
+      properties$samples <- params$samples
+      properties$validation_samples <- params$validation_samples
+      properties$epochs <- params$epochs
+      properties$batch_size <- params$batch_size
+      tfruns::write_run_metadata("properties", properties)
+    },
+    
+    write_model_info = function(model) {
+      tryCatch({
+        model_info <- list()
+        model_info$model <- py_str(model, line_length = 80L)
+        if (is.character(model$loss))
+          model_info$loss_function <- model$loss
+        else if (inherits(model$loss, "python.builtin.function"))
+          model_info$loss_function <- model$loss$`__name__`
+        optimizer <- model$optimizer
+        if (!is.null(optimizer)) {
+          model_info$optimizer <- py_str(optimizer)
+          model_info$learning_rate <- k_eval(optimizer$lr)                     
+        }
+        tfruns::write_run_metadata("properties", model_info)
+      }, error = function(e) {
+        warning("Unable to log model info: ", e$message, call. = FALSE)
+      })
+      
+    }
+  )
+)
+
+
 

--- a/R/model.R
+++ b/R/model.R
@@ -1146,8 +1146,6 @@ py_str.keras.engine.training.Model <- function(object,  line_length = getOption(
 # determine whether to view metrics or not
 resolve_view_metrics <- function(verbose, epochs, metrics) {
   (epochs > 1)          &&            # more than 1 epoch
-  !is.null(metrics)     &&            # have metrics
-  (length(metrics) > 0) &&            # capturing at least one metric
   (verbose > 0) &&                    # verbose mode is on
   !is.null(getOption("viewer")) &&    # have an internal viewer available
   nzchar(Sys.getenv("RSTUDIO"))       # running under RStudio

--- a/R/model.R
+++ b/R/model.R
@@ -447,6 +447,11 @@ fit.keras.engine.training.Model <-
   dataset <- resolve_tensorflow_dataset(x)
   if (inherits(dataset, "tensorflow.python.data.ops.dataset_ops.DatasetV2")) {
     args$x <- dataset
+    
+    if (!is.null(batch_size))
+      stop("You should not specify a `batch_size` if using a tfdataset.", 
+           call. = FALSE)
+    
   } else if (!is.null(dataset)) {
     args$x <- dataset[[1]]
     args$y <- dataset[[2]]

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -26,7 +26,11 @@ test_callback <- function(name, callback, h5py = FALSE, required_version = NULL)
   })
 }
 
-test_callback("progbar_logger", callback_progbar_logger())
+# disable progbar test as per: https://github.com/tensorflow/tensorflow/issues/38618#issuecomment-617907735
+if (tensorflow::tf_version() <= "2.1")
+  test_callback("progbar_logger", callback_progbar_logger())
+
+
 test_callback("model_checkpoint", callback_model_checkpoint(tempfile(fileext = ".h5")), h5py = TRUE)
 test_callback("learning_rate_scheduler", callback_learning_rate_scheduler(schedule = function (index, ...) {
   0.1


### PR DESCRIPTION
This  reimplements the metrics callbacks when using TF 2.2 since breaking changes in how parameters are passed to callbacks.

See here for more info: https://github.com/tensorflow/tensorflow/issues/38512