### PR TITLE
Missing text when hashing

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -235,6 +235,9 @@ text_hashing_trick <- function(text, n,
                                hash_function = NULL, 
                                filters = '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', 
                                lower = TRUE, split = ' ') {
+  if (length(text) != 1) {
+    stop("`text` should be length 1.")
+  }
   if (is.na(text)) {
     return(NA_integer_)
   }

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -235,6 +235,9 @@ text_hashing_trick <- function(text, n,
                                hash_function = NULL, 
                                filters = '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', 
                                lower = TRUE, split = ' ') {
+  if (is.na(text)) {
+    return(NA_integer_)
+  }
   keras$preprocessing$text$hashing_trick(
     text = text,
     n = as.integer(n),

--- a/tests/testthat/test-preprocessing.R
+++ b/tests/testthat/test-preprocessing.R
@@ -1,6 +1,6 @@
 context("preprocessing")
 
-source("utils.R")
+source(test_path("utils.R"))
 
 test_call_succeeds("pad_sequences", {
   a <- list(list(1), list(1,2), list(1,2,3))
@@ -26,6 +26,15 @@ test_call_succeeds("text_hashing_trick", required_version = "2.0.5", {
   text <- 'The cat sat on the mat.'
   encoded <- text_hashing_trick(text, 5)
   expect_equal(length(encoded), 6)
+})
+
+test_call_succeeds("missing text data", required_version = "2.0.5", {
+  texts <- c(
+    'Dogs and cats living together.',
+    NA_character_
+  )
+  expect_true(all(!is.na(text_hashing_trick(texts[1], 10))))
+  expect_true(all( is.na(text_hashing_trick(texts[2], 10))))
 })
 
 test_succeeds("use of text tokenizer", {
@@ -149,5 +158,4 @@ test_succeeds("flow images from directory works", {
   # evaluate
   eva <- evaluate_generator(model, gen, steps = 10)
 })
-
 

--- a/tests/testthat/test-preprocessing.R
+++ b/tests/testthat/test-preprocessing.R
@@ -29,6 +29,9 @@ test_call_succeeds("text_hashing_trick", required_version = "2.0.5", {
 })
 
 test_call_succeeds("missing text data", required_version = "2.0.5", {
+  expect_error(text_hashing_trick(letters, 10),
+               "`text` should be length 1")
+  
   texts <- c(
     'Dogs and cats living together.',
     NA_character_


### PR DESCRIPTION
Right now: 

``` r
keras::text_hashing_trick(NA_character_, 5)
#> [1] 4
```

<sup>Created on 2020-05-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

which seems wrong. This PR just returns a `NA_integer_`:

``` r
keras::text_hashing_trick(NA_character_, 5)
#> [1] NA
```

<sup>Created on 2020-05-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

It also gives an informative error when `text` is not a scalar. 