### PR TITLE
don't install scipy as it's already installed by tensorflow

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -147,8 +147,7 @@ install_keras <- function(method = c("auto", "virtualenv", "conda"),
     "h5py", 
     "pyyaml==3.12",
     "requests",
-    "Pillow",
-    "scipy"
+    "Pillow"
   ))
   
   # perform the install


### PR DESCRIPTION
Fix this error:

https://github.com/rstudio/keras/runs/828835224?check_suite_focus=true#step:9:280

Fix #1078