### PR TITLE
RNN `stateful` parameter documentation

### DIFF
--- a/man-roxygen/roxlate-recurrent-layer.R
+++ b/man-roxygen/roxlate-recurrent-layer.R
@@ -29,13 +29,15 @@
 #' between samples in different successive batches.
 #' 
 #' To enable statefulness:
-#'   - Specify `stateful=TRUE` in the layer constructor.
+#'   - Specify `stateful = TRUE` in the layer constructor.
 #'   - Specify a fixed batch size for your model. For sequential models,
 #'     pass `batch_input_shape = c(...)` to the first layer in your model.
 #'     For functional models with 1 or more Input layers, pass 
 #'     `batch_shape = c(...)` to all the first layers in your model.
 #'     This is the expected shape of your inputs *including the batch size*.
 #'     It should be a vector of integers, e.g. `c(32, 10, 100)`.
+#'     For dimensions which can vary (are not known ahead of time),
+#'     use `NULL` in place of an integer, e.g. `c(32, NULL, NULL)`.
 #'   - Specify `shuffle = FALSE` when calling fit().
 #' 
 #' To reset the states of your model, call `reset_states()` on either

--- a/man-roxygen/roxlate-recurrent-layer.R
+++ b/man-roxygen/roxlate-recurrent-layer.R
@@ -26,7 +26,9 @@
 #' You can set RNN layers to be 'stateful', which means that the states
 #' computed for the samples in one batch will be reused as initial states
 #' for the samples in the next batch. This assumes a one-to-one mapping
-#' between samples in different successive batches.
+#' between samples in different successive batches. For intuition behind
+#' statefulness, there is a helpful blog post here: 
+#' <http://philipperemy.github.io/keras-stateful-lstm/>
 #' 
 #' To enable statefulness:
 #'   - Specify `stateful = TRUE` in the layer constructor.


### PR DESCRIPTION
Added a couple notes to the `roxlate-recurrent-layer.R` template/documentation:
1. Use `NULL` for dimension sizes that are not known ahead of time (with example)
2. Link to a blog post I found helpful for understanding the `stateful` parameter. May help others too. @dfalbel may not be general enough for what you had in mind?

These correspond to the two commits included. I didn't rebuild the `.Rd` files&mdash;is it best practice to include the rebuild in the PR? I have a later version of `roxygen` and found that more changed than just those files which use the `roxlate-recurrent-layer` template.

Fixes #902. 