### PR TITLE
Add deprecation warning & alternative solution for multi_gpu_model()

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -164,7 +164,19 @@ keras_model_sequential <- function(layers = NULL, name = NULL) {
 #' }
 #'
 #' @family model functions
-#'
+#' @note This function is deprecated and has been removed from tensorflow on 
+#' 2020-04-01. To distribute your training across all available GPUS,
+#' you can use `tensorflow::tf$distribute$MirroredStrategy()`
+#' by creating your model like this:
+#' ```r
+#' strategy <- tensorflow::tf$distribute$MirroredStrategy()
+#' with(strategy$scope(), {
+#'   model <- application_xception(
+#'     weights = NULL,
+#'     input_shape = c(height, width, 3),
+#'     classes = num_classes
+#' })
+#' ```
 #' @export
 multi_gpu_model <- function(model, gpus = NULL, cpu_merge = TRUE, cpu_relocation = FALSE) {
   
@@ -172,6 +184,9 @@ multi_gpu_model <- function(model, gpus = NULL, cpu_merge = TRUE, cpu_relocation
     stop("You must provide an explicit gpus argument in Keras versions ",
          "prior to 2.1.4")
   }
+  
+  if (tensorflow::tf_version() >= "2.2")
+    stop("This function is deprecated as of TF version 2.2")
   
   args <- list(
     model = model,

--- a/man/multi_gpu_model.Rd
+++ b/man/multi_gpu_model.Rd
@@ -50,6 +50,18 @@ This induces quasi-linear speedup on up to 8 GPUs.
 This function is only available with the TensorFlow backend
 for the time being.
 }
+\note{
+This function is deprecated and has been removed from tensorflow on
+2020-04-01. You can use \code{tensorflow::tf$distribute$MirroredStrategy()}
+by creating your model like this:\if{html}{\out{<div class="r">}}\preformatted{strategy <- tensorflow::tf$distribute$MirroredStrategy()
+with(strategy$scope(), \{
+  model <- application_xception(
+    weights = NULL,
+    input_shape = c(height, width, 3),
+    classes = num_classes
+\})
+}\if{html}{\out{</div>}}
+}
 \section{Model Saving}{
 
 


### PR DESCRIPTION
Adresses #1093:
- Docs: Added a `@note` mentioning the deprecation (see https://www.tensorflow.org/api_docs/python/tf/distribute/MirroredStrategy) and provided a minimal example of using `tensorflow::tf$distribute$MirroredStrategy()` as an alternative implementation
- Added a check for tensorflow 2.2 to raise an error if used with the current version of tensorflow or greater:

```r
  if (tensorflow::tf_version() >= "2.2")
    stop("This function is deprecated as of TF version 2.2")
```

Please note that I am not certain how these kinds of deprecations are usually handled, I'm still very new to keras and tensorflow, so I'm happy to adjust the PR as needed.