### PR TITLE
Vocabulary of text vectorization layer

### DIFF
--- a/R/layer-text_vectorization.R
+++ b/R/layer-text_vectorization.R
@@ -93,9 +93,13 @@ layer_text_vectorization <- function(object, max_tokens = NULL, standardize = "l
 #' @seealso [set_vocabulary()]
 #' @export
 get_vocabulary <- function(object) {
-  python_path <- system.file("python", package = "keras")
-  tools <- import_from_path("kerastools", path = python_path)
-  tools$get_vocabulary$get_vocabulary(object)
+  if (tensorflow::tf_version() < "2.3") {
+    python_path <- system.file("python", package = "keras")
+    tools <- import_from_path("kerastools", path = python_path)
+    tools$get_vocabulary$get_vocabulary(object)  
+  } else {
+    object$get_vocabulary()
+  }
 }
 
 #' Sets vocabulary (and optionally document frequency) data for the layer
@@ -116,13 +120,22 @@ get_vocabulary <- function(object) {
 #'  data in "tfidf" mode; if an OOV value is supplied it will overwrite the
 #'  existing OOV value.
 #' @param append Whether to overwrite or append any existing vocabulary data.
+#'  (deprecated since TensorFlow >= 2.3)
 #' 
 #' @seealso [get_vocabulary()]
 #' 
 #' @export
 set_vocabulary <- function(object, vocab, df_data = NULL, oov_df_value = FALSE,
-                           append = FALSE) {
-  object$set_vocabulary(vocab, df_data, oov_df_value, append)
+                           append = NULL) {
+  
+  if (tensorflow::tf_version() < "2.3") {
+    if (is.null(append)) append <- FALSE
+    object$set_vocabulary(vocab, df_data, oov_df_value, append)
+  } else {
+    if (!is.null(append)) warning("append is ignored since tensorflow >= 2.3")
+    object$set_vocabulary(vocab, df_data = df_data, oov_df_value = oov_df_value)
+  }
+    
 }
 
 

--- a/tests/testthat/test-layer-text_vectorization.R
+++ b/tests/testthat/test-layer-text_vectorization.R
@@ -58,6 +58,7 @@ test_call_succeeds("can set and get the vocabulary of layer_text_vectorization",
   x <- matrix(c("hello world", "hello world"), ncol = 1)
   
   layer <- layer_text_vectorization()
+  layer$get_vocabulary()
   set_vocabulary(layer, vocab = c("hello", "world"))
   
   output <- layer(x)
@@ -65,7 +66,10 @@ test_call_succeeds("can set and get the vocabulary of layer_text_vectorization",
   vocab <- get_vocabulary(layer)
   
   expect_s3_class(output, "tensorflow.tensor")
-  expect_length(vocab, 2)
+  if (tensorflow::tf_version() < "2.3")
+    expect_length(vocab, 2)
+  else
+    expect_length(vocab, 4) # 0 is used for padding and 1 for unknown.
 })
 
 
@@ -78,7 +82,11 @@ test_call_succeeds("can use layer_text_vectorization", {
   
   layer <- layer_text_vectorization()
   layer %>% adapt(x_ds)
-  expect_length(get_vocabulary(layer), 2)
+  
+  if (tensorflow::tf_version() < "2.3")
+    expect_length(get_vocabulary(layer), 2)
+  else
+    expect_length(get_vocabulary(layer), 4) # 0 is used for padding and 1 for unknown.
 })
 
 


### PR DESCRIPTION
Fix errors when setting and getting the vocabulary of a text vectorization layer:

``` r
library(keras)
layer <- layer_text_vectorization()
set_vocabulary(layer, c("hello", "world"))
#> Error in py_call_impl(callable, dots$args, dots$keywords): TypeError: set_vocabulary() takes from 2 to 4 positional arguments but 5 were given
get_vocabulary(layer)
#> list()
```

<sup>Created on 2020-10-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>