### PR TITLE
Fix drop_duplicates DeprecationWarning with tf 2.3

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -887,8 +887,8 @@ flow_images_from_directory <- function(
 #' @param y_col string or list, column/s in dataframe that has the target data.
 #' @param color_mode one of "grayscale", "rgb". Default: "rgb". Whether the 
 #'   images will be converted to have 1 or 3 color channels.
-#' @param drop_duplicates Boolean, whether to drop duplicate rows based on 
-#'   filename.
+#' @param drop_duplicates (deprecated in TF >= 2.3) Boolean, whether to drop 
+#'   duplicate rows based on filename. The default value is `TRUE`.
 #' @param classes optional list of classes (e.g. `c('dogs', 'cats')`. Default: 
 #'  `NULL` If not provided, the list of classes will be automatically inferred 
 #'  from the `y_col`, which will map to the label indices, will be alphanumeric). 

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -925,7 +925,7 @@ flow_images_from_dataframe <- function(
   color_mode = "rgb", classes = NULL, class_mode = "categorical", 
   batch_size = 32, shuffle = TRUE, seed = NULL, save_to_dir = NULL, 
   save_prefix = "", save_format = "png", subset = NULL, 
-  interpolation = "nearest", drop_duplicates = TRUE) {
+  interpolation = "nearest", drop_duplicates = NULL) {
   
   if (!reticulate::py_module_available("pandas"))
     stop("Pandas (python module) must be installed in the same environment as Keras.", 
@@ -957,12 +957,12 @@ flow_images_from_dataframe <- function(
   if (keras_version() >= "2.1.5") 
     args$subset <- subset
   
-  if (tensorflow::tf_version() >= "2.3") {
-    if(drop_duplicates) {
-      warning("\'drop_duplicates\' is deprecated as of tensorflow 2.3 and will be ignored. Make sure the supplied dataframe does not contain duplicates.") 
-    }
-    args$drop_duplicates <- NULL
+  if(!is.null(drop_duplicates) && tensorflow::tf_version() >= "2.3") {
+    warning("\'drop_duplicates\' is deprecated as of tensorflow 2.3 and will be ignored. Make sure the supplied dataframe does not contain duplicates.") 
   }
+  
+  if (is.null(drop_duplicates) && tensorflow::tf_version() < "2.3")
+    args$drop_duplicates <- TRUE
   
   do.call(generator$flow_from_dataframe, args)
 }

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -957,6 +957,13 @@ flow_images_from_dataframe <- function(
   if (keras_version() >= "2.1.5") 
     args$subset <- subset
   
+  if (tensorflow::tf_version() >= "2.3") {
+    if(drop_duplicates) {
+      warning("\'drop_duplicates\' is deprecated as of tensorflow 2.3 and will be ignored. Make sure the supplied dataframe does not contain duplicates.") 
+    }
+    args$drop_duplicates <- NULL
+  }
+  
   do.call(generator$flow_from_dataframe, args)
 }
 

--- a/man/flow_images_from_dataframe.Rd
+++ b/man/flow_images_from_dataframe.Rd
@@ -23,7 +23,7 @@ flow_images_from_dataframe(
   save_format = "png",
   subset = NULL,
   interpolation = "nearest",
-  drop_duplicates = TRUE
+  drop_duplicates = NULL
 )
 }
 \arguments{
@@ -104,8 +104,8 @@ installed, "lanczos" is also supported. If PIL version 3.4.0 or newer is
 installed, "box" and "hamming" are also supported. By default, "nearest"
 is used.}
 
-\item{drop_duplicates}{Boolean, whether to drop duplicate rows based on
-filename.}
+\item{drop_duplicates}{(deprecated in TF >= 2.3) Boolean, whether to drop
+duplicate rows based on filename. The default value is \code{TRUE}.}
 }
 \description{
 Takes the dataframe and the path to a directory and generates batches of

--- a/tests/testthat/test-preprocessing.R
+++ b/tests/testthat/test-preprocessing.R
@@ -102,18 +102,33 @@ test_succeeds("flow images from dataframe works", {
       class = letters[1:10], 
       stringsAsFactors = FALSE
       )
+    
     img_gen <- flow_images_from_dataframe(
       df, 
       directory = ".", 
       x_col = "fname", 
-      y_col = "class", 
-      drop_duplicates = FALSE
-      )
+      y_col = "class"
+    )
     
     batch <- reticulate::iter_next(img_gen)
     
     expect_equal(dim(batch[[1]]), c(10, 256, 256, 3))
     expect_equal(dim(batch[[2]]), c(10, 10))
+    
+    if (tensorflow::tf_version() >= "2.3") {
+      
+      expect_warning(
+        img_gen <- flow_images_from_dataframe(
+          df, 
+          directory = ".", 
+          x_col = "fname", 
+          y_col = "class", 
+          drop_duplicates = TRUE
+        )
+      )
+      
+    }
+    
   }
 })
 


### PR DESCRIPTION
With tensorflow 2.3 drop_duplicates in flow_images_from_dataframe gives a DeprecationWarning:

``` r
library(keras)
library(tensorflow)
library(imager)
library(dplyr)

reticulate::use_condaenv("tf_2.3", required = TRUE)
tf_version()
#> [1] '2.3'
packageVersion("keras")
#> [1] '2.3.0.0'

# Save sample of minst to disk
minst_data <- tf$keras$datasets$mnist$load_data()
n_imgs <- 1000 # Use 1000 test images
minst_meta <- data.frame(file = paste0("minst_sample/imgs/img_", 1:n_imgs, ".png"),
                         class = paste0("N_", minst_data[[2]][[2]][1:n_imgs]))
dir.create("minst_sample/imgs/", recursive = TRUE, showWarnings = FALSE)
for(i in 1:n_imgs) {
  imager::save.image(imager::as.cimg(minst_data[[2]][[1]][i,,]),
                     file = minst_meta$file[i])
}
rm(i, minst_data, n_imgs)
write.csv(minst_meta, file="minst_sample/minst_meta.csv", row.names = FALSE)
minst_meta <- read.csv("minst_sample/minst_meta.csv")

# Create splits
minst_split <- minst_meta %>%
  mutate(split = sample(c(rep("train", ceiling(0.6*n())),
                          rep("val", ceiling(0.2*n())),
                          rep("test", ceiling(0.2*n()))),
                        size = n()))

# Create flows
train_flow <- keras::flow_images_from_dataframe(dataframe = minst_meta,
                                                x_col = "file",
                                                y_col = "class",
                                                batch_size = 16L,
                                                drop_duplicates = FALSE)
```

Throws following DeprecationWarning:
``` sh
--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\GEORGS~1\MINICO~1\envs\tf_2.3\lib\logging\__init__.py", line 1025, in emit
    msg = self.format(record)
  File "C:\Users\GEORGS~1\MINICO~1\envs\tf_2.3\lib\logging\__init__.py", line 869, in format
    return fmt.format(record)
  File "C:\Users\GEORGS~1\MINICO~1\envs\tf_2.3\lib\logging\__init__.py", line 608, in format
    record.message = record.getMessage()
  File "C:\Users\GEORGS~1\MINICO~1\envs\tf_2.3\lib\logging\__init__.py", line 369, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "C:\Users\GEORGS~1\MINICO~1\envs\tf_2.3\lib\site-packages\tensorflow\python\keras\preprocessing\image.py", line 1079, in flow_from_dataframe
    DeprecationWarning)
  File "C:\Users\GEORGS~1\MINICO~1\envs\tf_2.3\lib\site-packages\tensorflow\python\platform\tf_logging.py", line 173, in warn
    get_logger().warning(msg, *args, **kwargs)
Message: 'drop_duplicates is deprecated, you can drop duplicates by using the pandas.DataFrame.drop_duplicates method.'
Arguments: (<class 'DeprecationWarning'>,)
Found 1000 validated image filenames belonging to 10 classes.
```
<sup>Created on 2020-10-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This PR removes the DeprecationWarning (or throws an R warning if `drop_duplicates = TRUE`). However, I am unsure whether its good practice to leave the default of `drop_duplicates ` to `TRUE`.