### PR TITLE
Correction to merged PR #1139

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -958,7 +958,8 @@ flow_images_from_dataframe <- function(
     args$subset <- subset
   
   if(!is.null(drop_duplicates) && tensorflow::tf_version() >= "2.3") {
-    warning("\'drop_duplicates\' is deprecated as of tensorflow 2.3 and will be ignored. Make sure the supplied dataframe does not contain duplicates.") 
+    warning("\'drop_duplicates\' is deprecated as of tensorflow 2.3 and will be ignored. Make sure the supplied dataframe does not contain duplicates.")
+    args$drop_duplicates <- NULL
   }
   
   if (is.null(drop_duplicates) && tensorflow::tf_version() < "2.3")


### PR DESCRIPTION
Hi,
due to the way @dfalbel changed my pull request #1139, the DeprecationWarning from tensorflow will still be shown (along with the R one). This is because even though in creation of the `args` list the `drop_duplicates` element is set to `NULL`, its still an element of `args`. See this minimal example:

``` r
drop_duplictaes = NULL

args <- list(drop_duplictaes = drop_duplictaes)
print(args)
#> $drop_duplictaes
#> NULL

args$drop_duplictaes <- NULL
print(args)
#> named list()
```

<sup>Created on 2020-11-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


As shown in the example, setting `drop_duplicates` to  `NULL`after the creation of `args` will actually remove the `drop_duplicates` element and, hence, get rid of the DeprecationWarning from tensorflow (not 100% certain if that is desired?).