### PR TITLE
hdf5 has been removed in tf 2.4

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -92,6 +92,9 @@ get_file <- function(fname, origin, file_hash = NULL, cache_subdir = "datasets",
 #' @export
 hdf5_matrix <- function(datapath, dataset, start = 0, end = NULL, normalizer = NULL) {
   
+  if (tensorflow::tf_version() >= "2.4")
+    stop("This function have been removed in TensorFlow version 2.4 or later.")
+  
   if (!have_h5py())
     stop("The h5py Python package is required to read h5 files")
   

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -19,6 +19,9 @@ test_call_succeeds("get_file", {
 
 test_call_succeeds("hdf5_matrix", {
   
+  if (tensorflow::tf_version() >= "2.4")
+    skip("hdf5 matrix have been removed in tf >= 2.4")
+  
   if (!keras:::have_h5py())
     skip("h5py not available for testing")
   


### PR DESCRIPTION
It seems that HDF5Matrix has been removed from Keras in TF 2.4.
It used to be an utility but can't be found anymore here: https://keras.io/api/utils/