### PR TITLE
warning for keras implementations != than tensorflow.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     magrittr, 
     zeallot,
     methods,
-    R6
+    R6,
+    rlang
 Suggests: 
     ggplot2,
     testthat (>= 2.1.0),

--- a/R/package.R
+++ b/R/package.R
@@ -168,7 +168,13 @@ resolve_implementation_module <- function() {
 }
 
 get_keras_implementation <- function(default = "tensorflow") {
-  get_keras_option("KERAS_IMPLEMENTATION", default = default)
+  out <- get_keras_option("KERAS_IMPLEMENTATION", default = default)
+  if (out != "tensorflow")
+    rlang::warn(c(
+      paste0("We no longer support the '", out, "' Keras implementation."),
+      "Use Sys.setenv(KERAS_IMPLEMENTATION='tensorflow') or unset that environment variable."
+    ), .frequency = "once", .frequency_id = "implementation")
+  out
 }
 
 get_keras_python <- function(default = NULL) {


### PR DESCRIPTION
Keras implementation is no longer maintained in favor of tensorflow's and we should warn users that are still setting that.