### PR TITLE
This is an attempt to fix the `fit_generator` issue

### DIFF
--- a/inst/python/kerastools/generator.py
+++ b/inst/python/kerastools/generator.py
@@ -1,6 +1,7 @@
 
 import itertools
-
+import threading, queue, time
+import concurrent.futures
 
 def iter_generator(iter):
   
@@ -21,4 +22,47 @@ def dataset_generator(dataset, session):
 
   return gen()
 
-
+is_finished = False
+def fit_thread (model, generator, args):
+  global is_finished
+  is_finished = False
+  q = queue.Queue(10)
+  
+  def event_loop(generator, future):
+      global is_finished
+      for element in generator:
+          while True:
+              try:
+                  q.put(element, timeout = 0.01)
+                  break
+              except queue.Full:
+                  if is_finished:
+                      break
+                  if future.done():
+                      break
+          if is_finished:
+              break
+          if future.done():
+              break
+      else:
+          q.put('__FINISH__')
+  
+  def thread_fit():
+    global is_finished
+    def thread_gen():
+      global is_finished
+      while True:
+        e = q.get()
+        if e == '__FINISH__':
+          break
+        yield e
+    output = model.fit(thread_gen(), **args)
+    is_finished = True
+    return output
+    
+  with concurrent.futures.ThreadPoolExecutor() as executor:
+    future = executor.submit(thread_fit)
+    event_loop(generator, future)
+    out = future.result()
+  
+  return out


### PR DESCRIPTION
Run `fit` from a different thread and leave the main loop free to execute the generator.

This indeed works, however this adds problems in other parts, for example, this way, callbacks would be executed in a different thread too and would need to be handled differently.

Probably the same thing for custom models. Unfortunately this workaround is not a great solution.

See #986 

I opened an issue in TensorFlow as I think this is probably almost impossible to fix in the R side:
https://github.com/tensorflow/tensorflow/issues/47321