### PR TITLE
Fit generator

### DIFF
--- a/R/metrics-callback.R
+++ b/R/metrics-callback.R
@@ -158,7 +158,7 @@ KerasMetricsCallbackV2 <- R6::R6Class(
     },
     
     on_epoch_end = function(epoch, logs = NULL) {
-      
+    
       if (epoch - self$initial_epoch == 0) {
         
         metric_names <- names(logs)
@@ -210,14 +210,13 @@ KerasMetricsCallbackV2 <- R6::R6Class(
         # pump events
         Sys.sleep(sleep)
       }
-      
       # record metrics
       tfruns::write_run_metadata("metrics", metrics)
-      
     },
     
     # convert keras history to metrics data frame suitable for plotting
     as_metrics_df = function(history) {
+      
       # create metrics data frame
       df <- as.data.frame(history$metrics)
       

--- a/R/model-legacy.R
+++ b/R/model-legacy.R
@@ -1,0 +1,120 @@
+fit_generator_legacy <- function(object, generator, steps_per_epoch, epochs = 1, 
+                          verbose=getOption("keras.fit_verbose", default = 1), callbacks = NULL, 
+                          view_metrics = getOption("keras.view_metrics", default = "auto"),
+                          validation_data = NULL, validation_steps = NULL, 
+                          class_weight = NULL, max_queue_size = 10, workers = 1, initial_epoch = 0) {
+  
+  # resolve view_metrics
+  if (identical(view_metrics, "auto"))
+    view_metrics <- resolve_view_metrics(verbose, epochs, object$metrics)
+  
+  if (is.list(validation_data))
+    validation_data <- do.call(reticulate::tuple, keras_array(validation_data))
+  
+  history <- call_generator_function(object$fit_generator, list(
+    generator = generator,
+    steps_per_epoch = as.integer(steps_per_epoch),
+    epochs = as.integer(epochs),
+    verbose = as.integer(verbose),
+    callbacks = normalize_callbacks_with_metrics(view_metrics, initial_epoch, callbacks),
+    validation_data = validation_data,
+    validation_steps = as_nullable_integer(validation_steps),
+    class_weight = as_class_weight(class_weight),
+    max_queue_size = as.integer(max_queue_size),
+    workers = as.integer(workers),
+    initial_epoch = as.integer(initial_epoch) 
+  ))
+  
+  # convert to a keras_training history object
+  history <- to_keras_training_history(history)
+  
+  # write metadata from history
+  write_history_metadata(history)
+  
+  # return the history invisibly
+  invisible(history)
+}
+
+evaluate_generator_legacy <- function(object, generator, steps, max_queue_size = 10, workers = 1,
+                               callbacks = NULL) {
+  
+  args <- list(
+    generator = generator,
+    steps = as.integer(steps),
+    max_queue_size = as.integer(max_queue_size),
+    workers = as.integer(workers)
+  )
+  
+  args <- resolve_callbacks(args, callbacks)
+  
+  # perform evaluation
+  result <- call_generator_function(object$evaluate_generator, args)
+  
+  # apply names
+  names(result) <- object$metrics_names
+  
+  # write run data
+  tfruns::write_run_metadata("evaluation", result)
+  
+  # return result
+  result
+}
+
+predict_generator_legacy <- function(object, generator, steps, max_queue_size = 10, workers = 1, verbose = 0,
+                              callbacks = NULL) {
+  
+  args <- list(
+    generator = generator,
+    steps = as.integer(steps),
+    max_queue_size = as.integer(max_queue_size),
+    workers = as.integer(workers)
+  )
+  
+  if (keras_version() >= "2.0.1")
+    args$verbose <- as.integer(verbose)
+  
+  args <- resolve_callbacks(args, callbacks)
+  
+  call_generator_function(object$predict_generator, args)
+}
+
+call_generator_function <- function(func, args) {
+  
+  # check if any generators should run on the main thread
+  use_main_thread_generator <- 
+    is_main_thread_generator(args$generator) ||
+    is_main_thread_generator(args$validation_data)
+  
+  # handle generators
+  args$generator <- as_generator(args$generator)
+  if (!is.null(args$validation_data))
+    args$validation_data <- as_generator(args$validation_data)
+  
+  # force use of thread based concurrency
+  if (keras_version() >= "2.0.6") {
+    args$use_multiprocessing <- FALSE
+  } else {
+    args$max_q_size <- args$max_queue_size
+    args$max_queue_size <- NULL
+    args$pickle_safe <- FALSE
+  }
+  
+  # if it's a main thread generator then force workers to correct value
+  if (use_main_thread_generator) {
+    
+    # error to use workers > 1 for main thread generator
+    if (args$workers > 1) {
+      stop('You may not specify workers > 1 for R based generator functions (R ',
+           'generators must run on the main thread)', call. = FALSE)
+    }
+    
+    # set workers to 0 for versions of keras that support this
+    if (keras_version() >= "2.1.2")
+      args$workers = 0L
+    else
+      args$workers = 1L
+  }
+  
+  # call the generator
+  do.call(func, args)
+}

--- a/R/model.R
+++ b/R/model.R
@@ -358,15 +358,14 @@ resolve_input_data <- function(x, y = NULL) {
   args <- list()
   if (inherits(dataset, "tensorflow.python.data.ops.dataset_ops.DatasetV2")) {
     args$x <- dataset
-    if (!is.null(batch_size))
-      stop("You should not specify a `batch_size` if using a tfdataset.", 
-           call. = FALSE)
   } else if (!is.null(dataset)) {
     args$x <- dataset[[1]]
     args$y <- dataset[[2]]
   } else if (is.function(x)) {
     args$x <- as_generator(x)
   } else if (inherits(x, "python.builtin.iterator")) {
+    args$x <- x
+  } else if (inherits(x, "keras.utils.data_utils.Sequence")) {
     args$x <- x
   } else {
     if (!is.null(x))
@@ -386,6 +385,8 @@ resolve_validation_data <- function(validation_data) {
     else if (is.function(validation_data))
       args$validation_data <- as_generator(validation_data)
     else if (inherits(validation_data, "python.builtin.iterator"))
+      args$validation_data <- validation_data
+    else if (inherits(validation_data, "keras.utils.data_utils.Sequence"))
       args$validation_data <- validation_data
     else {
       args$validation_data <- keras_array(validation_data)  

--- a/R/model.R
+++ b/R/model.R
@@ -506,7 +506,7 @@ fit.keras.engine.training.Model <-
     stop("Don't set batch_size with a tfdataset as input.", call. = FALSE)
     
   # defaults
-  if (is.null(batch_size) && is.null(steps_per_epoch))
+  if (is.null(batch_size) && is.null(steps_per_epoch) && !is_tensorflow_dataset(x))
     batch_size <- 32L
   
   # resolve view_metrics

--- a/R/model.R
+++ b/R/model.R
@@ -433,7 +433,9 @@ resolve_main_thread_generators <- function(x, callback_type = "on_train_batch_be
 #' @param x Vector, matrix, or array of training data (or list if the model has
 #'   multiple inputs). If all inputs in the model are named, you can also pass a
 #'   list mapping input names to data. `x` can be `NULL` (default) if feeding 
-#'   from framework-native tensors (e.g. TensorFlow data tensors).
+#'   from framework-native tensors (e.g. TensorFlow data tensors). You can also
+#'   pass a `tfdataset` or a generator returning a list with `(inputs, targets)` or 
+#'   `(inputs, targets, sample_weights)`.
 #' @param y  Vector, matrix, or array of target (label) data (or list if the model has
 #'   multiple outputs). If all outputs in the model are named, you can also pass
 #'   a list mapping output names to data. `y` can be `NULL` (default) if feeding 
@@ -571,7 +573,9 @@ fit.keras.engine.training.Model <-
 #' @param x Vector, matrix, or array of test data (or list if the model has
 #'   multiple inputs). If all inputs in the model are named, you can also pass a
 #'   list mapping input names to data. `x` can be `NULL` (default) if feeding 
-#'   from framework-native tensors (e.g. TensorFlow data tensors).
+#'   from framework-native tensors (e.g. TensorFlow data tensors). You can also
+#'   pass a `tfdataset` or a generator returning a list with `(inputs, targets)` or 
+#'   `(inputs, targets, sample_weights)`.
 #' @param y  Vector, matrix, or array of target (label) data (or list if the model has
 #'   multiple outputs). If all outputs in the model are named, you can also pass
 #'   a list mapping output names to data. `y` can be `NULL` (default) if feeding 
@@ -652,7 +656,9 @@ resolve_callbacks <- function(args, callbacks) {
 #' @inheritParams evaluate.keras.engine.training.Model
 #'
 #' @param object Keras model
-#' @param x Input data (vector, matrix, or array)
+#' @param x Input data (vector, matrix, or array). You can also
+#'   pass a `tfdataset` or a generator returning a list with `(inputs, targets)` or 
+#'   `(inputs, targets, sample_weights)`.
 #' @param batch_size Integer. If unspecified, it will default to 32.
 #' @param verbose Verbosity mode, 0 or 1.
 #' @param callbacks List of callbacks to apply during prediction. 
@@ -899,6 +905,8 @@ fit_generator <- function(object, generator, steps_per_epoch, epochs = 1,
       initial_epoch = initial_epoch
     ))
   
+  warning("`fit_generator` is deprecated. Use `fit` instead, it now accept generators.")
+  
   # redirect to `model.fit`
   args <- list(
     object = object,
@@ -945,6 +953,8 @@ evaluate_generator <- function(object, generator, steps, max_queue_size = 10, wo
       object, generator, steps, max_queue_size, workers,
       callbacks))
   
+  warning("`evaluate_generator` is deprecated. Use `evaluate` instead, it now accept generators.")
+  
   args <- list(
     object = object,
     x = generator,
@@ -987,6 +997,8 @@ predict_generator <- function(object, generator, steps, max_queue_size = 10, wor
     return(predict_generator_legacy(object, generator, steps, max_queue_size, 
                              workers, verbose, callbacks))
   
+  warning("`predict_generator` is deprecated. Use `predict` instead, it now accept generators.")
+  
   args <- list(
     object = object,
     x = generator,
@@ -999,9 +1011,6 @@ predict_generator <- function(object, generator, steps, max_queue_size = 10, wor
   
   do.call(predict, args)
 }
-
-
-
 
 as_generator <- function(x) {
   UseMethod("as_generator")

--- a/R/model.R
+++ b/R/model.R
@@ -398,6 +398,11 @@ resolve_validation_data <- function(validation_data) {
 }
 
 resolve_main_thread_generators <- function(x, callback_type = "on_train_batch_begin") {
+  
+  if (tensorflow::tf_version() == "2.1")
+    stop("Using generators that call R functions is not supported in TensorFlow 2.1 ",
+         "Please upgrade your TF installation or downgrade to 2.0", call. = FALSE)
+  
   # we need a hack to make sure the generator is evaluated in the main thread.
   python_path <- system.file("python", package = "keras")
   tools <- reticulate::import_from_path("kerastools", path = python_path)

--- a/R/model.R
+++ b/R/model.R
@@ -878,6 +878,22 @@ fit_generator <- function(object, generator, steps_per_epoch, epochs = 1,
                           validation_data = NULL, validation_steps = NULL, 
                           class_weight = NULL, max_queue_size = 10, workers = 1, initial_epoch = 0) {
   
+  if (tensorflow::tf_version() <= "2.0")
+    return(fit_generator_legacy(
+      object = object, 
+      generator = generator, 
+      steps_per_epoch = steps_per_epoch, 
+      epochs = epochs,
+      verbose=verbose,
+      view_metrics = view_metrics,
+      validation_data = validation_data,
+      validation_steps = validation_steps,
+      class_weight = class_weight,
+      max_queue_size = max_queue_size,
+      workers = workers,
+      initial_epoch = initial_epoch
+    ))
+  
   # redirect to `model.fit`
   args <- list(
     object = object,
@@ -919,6 +935,11 @@ fit_generator <- function(object, generator, steps_per_epoch, epochs = 1,
 evaluate_generator <- function(object, generator, steps, max_queue_size = 10, workers = 1,
                                callbacks = NULL) {
   
+  if (tensorflow::tf_version() <= "2.0")
+    return(evaluate_generator_legacy(
+      object, generator, steps, max_queue_size, workers,
+      callbacks))
+  
   args <- list(
     object = object,
     x = generator,
@@ -956,6 +977,10 @@ evaluate_generator <- function(object, generator, steps, max_queue_size = 10, wo
 #' @export
 predict_generator <- function(object, generator, steps, max_queue_size = 10, workers = 1, verbose = 0,
                               callbacks = NULL) {
+  
+  if (tensorflow::tf_version() <= "2.0")
+    return(predict_generator_legacy(object, generator, steps, max_queue_size, 
+                             workers, verbose, callbacks))
   
   args <- list(
     object = object,

--- a/R/model.R
+++ b/R/model.R
@@ -497,9 +497,11 @@ fit.keras.engine.training.Model <-
            class_weight=NULL, sample_weight=NULL, initial_epoch=0,
            steps_per_epoch=NULL, validation_steps=NULL, ...) {
     
+  if (!is.null(batch_size) && is_tensorflow_dataset(x))
+    stop("Don't set batch_size with a tfdataset as input.", call. = FALSE)
+    
   # defaults
-  if (is.null(batch_size) && is.null(steps_per_epoch) && 
-      !is_tensorflow_dataset(x))
+  if (is.null(batch_size) && is.null(steps_per_epoch))
     batch_size <- 32L
   
   # resolve view_metrics

--- a/inst/python/kerastools/generator.py
+++ b/inst/python/kerastools/generator.py
@@ -1,6 +1,7 @@
 
 import itertools
-
+import threading, queue, time
+import concurrent.futures
 
 def iter_generator(iter):
   
@@ -21,4 +22,47 @@ def dataset_generator(dataset, session):
 
   return gen()
 
-
+is_finished = False
+def fit_thread (model, generator, args):
+  global is_finished
+  is_finished = False
+  q = queue.Queue(10)
+  
+  def event_loop(generator, future):
+      global is_finished
+      for element in generator:
+          while True:
+              try:
+                  q.put(element, timeout = 0.01)
+                  break
+              except queue.Full:
+                  if is_finished:
+                      break
+                  if future.done():
+                      break
+          if is_finished:
+              break
+          if future.done():
+              break
+      else:
+          q.put('__FINISH__')
+  
+  def thread_fit():
+    global is_finished
+    def thread_gen():
+      global is_finished
+      while True:
+        e = q.get()
+        if e == '__FINISH__':
+          break
+        yield e
+    output = model.fit(thread_gen(), **args)
+    is_finished = True
+    return output
+    
+  with concurrent.futures.ThreadPoolExecutor() as executor:
+    future = executor.submit(thread_fit)
+    event_loop(generator, future)
+    out = future.result()
+  
+  return out

--- a/inst/python/kerastools/generator.py
+++ b/inst/python/kerastools/generator.py
@@ -1,7 +1,6 @@
 
 import itertools
-import threading, queue, time
-import concurrent.futures
+import types
 
 def iter_generator(iter):
   
@@ -22,47 +21,3 @@ def dataset_generator(dataset, session):
 
   return gen()
 
-is_finished = False
-def fit_thread (model, generator, args):
-  global is_finished
-  is_finished = False
-  q = queue.Queue(10)
-  
-  def event_loop(generator, future):
-      global is_finished
-      for element in generator:
-          while True:
-              try:
-                  q.put(element, timeout = 0.01)
-                  break
-              except queue.Full:
-                  if is_finished:
-                      break
-                  if future.done():
-                      break
-          if is_finished:
-              break
-          if future.done():
-              break
-      else:
-          q.put('__FINISH__')
-  
-  def thread_fit():
-    global is_finished
-    def thread_gen():
-      global is_finished
-      while True:
-        e = q.get()
-        if e == '__FINISH__':
-          break
-        yield e
-    output = model.fit(thread_gen(), **args)
-    is_finished = True
-    return output
-    
-  with concurrent.futures.ThreadPoolExecutor() as executor:
-    future = executor.submit(thread_fit)
-    event_loop(generator, future)
-    out = future.result()
-  
-  return out

--- a/inst/python/kerastools/model.py
+++ b/inst/python/kerastools/model.py
@@ -1,6 +1,9 @@
 
 
 import os
+import threading
+import queue
+import concurrent.futures
 
 if (os.getenv('KERAS_IMPLEMENTATION', 'tensorflow') == 'keras'):
   from keras.engine import Model
@@ -17,3 +20,32 @@ class RModel(Model):
  
   def call(self, inputs, mask = None, **kwargs):
     return self._r_call(inputs, mask, **kwargs)
+
+
+def as_generator (r_generator):
+  
+  q = queue.Queue(maxsize = 10)
+  it = iter(r_generator)
+
+  # this generator will simply take elements from the queue
+  # until it's finished.
+  def keras_generator ():
+    while True:
+      e = q.get()
+      if e == '__FINISH__':
+          break
+      yield e
+  
+  def eval_loop ():
+    try:
+      el = next(it)
+    except StopIteration:
+      el = "__FINISH__"
+    
+    q.put(el)
+
+  eval_loop()
+  
+  return keras_generator(), eval_loop
+
+    

--- a/man/evaluate.keras.engine.training.Model.Rd
+++ b/man/evaluate.keras.engine.training.Model.Rd
@@ -22,7 +22,9 @@
 \item{x}{Vector, matrix, or array of test data (or list if the model has
 multiple inputs). If all inputs in the model are named, you can also pass a
 list mapping input names to data. \code{x} can be \code{NULL} (default) if feeding
-from framework-native tensors (e.g. TensorFlow data tensors).}
+from framework-native tensors (e.g. TensorFlow data tensors). You can also
+pass a \code{tfdataset} or a generator returning a list with \verb{(inputs, targets)} or
+\verb{(inputs, targets, sample_weights)}.}
 
 \item{y}{Vector, matrix, or array of target (label) data (or list if the model has
 multiple outputs). If all outputs in the model are named, you can also pass

--- a/man/fit.keras.engine.training.Model.Rd
+++ b/man/fit.keras.engine.training.Model.Rd
@@ -30,7 +30,9 @@
 \item{x}{Vector, matrix, or array of training data (or list if the model has
 multiple inputs). If all inputs in the model are named, you can also pass a
 list mapping input names to data. \code{x} can be \code{NULL} (default) if feeding
-from framework-native tensors (e.g. TensorFlow data tensors).}
+from framework-native tensors (e.g. TensorFlow data tensors). You can also
+pass a \code{tfdataset} or a generator returning a list with \verb{(inputs, targets)} or
+\verb{(inputs, targets, sample_weights)}.}
 
 \item{y}{Vector, matrix, or array of target (label) data (or list if the model has
 multiple outputs). If all outputs in the model are named, you can also pass

--- a/man/predict.keras.engine.training.Model.Rd
+++ b/man/predict.keras.engine.training.Model.Rd
@@ -17,7 +17,9 @@
 \arguments{
 \item{object}{Keras model}
 
-\item{x}{Input data (vector, matrix, or array)}
+\item{x}{Input data (vector, matrix, or array). You can also
+pass a \code{tfdataset} or a generator returning a list with \verb{(inputs, targets)} or
+\verb{(inputs, targets, sample_weights)}.}
 
 \item{batch_size}{Integer. If unspecified, it will default to 32.}
 

--- a/man/predict_on_batch.Rd
+++ b/man/predict_on_batch.Rd
@@ -9,7 +9,9 @@ predict_on_batch(object, x)
 \arguments{
 \item{object}{Keras model object}
 
-\item{x}{Input data (vector, matrix, or array)}
+\item{x}{Input data (vector, matrix, or array). You can also
+pass a \code{tfdataset} or a generator returning a list with \verb{(inputs, targets)} or
+\verb{(inputs, targets, sample_weights)}.}
 }
 \value{
 array of predictions.

--- a/man/predict_proba.Rd
+++ b/man/predict_proba.Rd
@@ -12,7 +12,9 @@ predict_classes(object, x, batch_size = NULL, verbose = 0, steps = NULL)
 \arguments{
 \item{object}{Keras model object}
 
-\item{x}{Input data (vector, matrix, or array)}
+\item{x}{Input data (vector, matrix, or array). You can also
+pass a \code{tfdataset} or a generator returning a list with \verb{(inputs, targets)} or
+\verb{(inputs, targets, sample_weights)}.}
 
 \item{batch_size}{Integer. If unspecified, it will default to 32.}
 

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -5,6 +5,13 @@ skip_if_no_keras <- function(required_version = NULL) {
     skip("required keras version not available for testing")
 }
 
+expect_warning_if <- function(cond, expr) {
+  expect_warning(
+    expr,
+    regexp = if (cond) NULL else NA
+  )
+}
+
 py_capture_output <- reticulate::import("IPython")$utils$capture$capture_output
 
 test_succeeds <- function(desc, expr, required_version = NULL) {

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -165,7 +165,7 @@ expect_warns_and_out <- function(warns, out) {
 
 test_succeeds("on predict/evaluation callbacks", {
   
-  if (tensorflow::tf_version() == "2.1")
+  if (tensorflow::tf_version() <= "2.1")
     skip("don't work in tf2.1")
   
   CustomCallback <- R6::R6Class(
@@ -208,7 +208,7 @@ test_succeeds("on predict/evaluation callbacks", {
   
   warns <- capture_warnings(
     out <- capture_output(
-      pred <- predict_generator(model, gen, callbacks = cc, steps = 1)  
+      pred <- predict(model, gen, callbacks = cc, steps = 1)  
     )
   )
   expect_warns_and_out(warns, out)
@@ -227,7 +227,7 @@ test_succeeds("on predict/evaluation callbacks", {
   
   warns <- capture_warnings(
     out <- capture_output(
-      ev <- evaluate_generator(model, gen, callbacks = cc, steps = 1)
+      ev <- evaluate(model, gen, callbacks = cc, steps = 1)
     )
   )
   expect_warns_and_out(warns, out)

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -165,6 +165,9 @@ expect_warns_and_out <- function(warns, out) {
 
 test_succeeds("on predict/evaluation callbacks", {
   
+  if (tensorflow::tf_version() == "2.1")
+    skip("don't work in tf2.1")
+  
   CustomCallback <- R6::R6Class(
     "CustomCallback",
     inherit = KerasCallback,

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -165,9 +165,6 @@ expect_warns_and_out <- function(warns, out) {
 
 test_succeeds("on predict/evaluation callbacks", {
   
-  if (tensorflow::tf_version() >= "2.1")
-    skip("TODO: R based generators are not working with TF >= 2.1")
-  
   CustomCallback <- R6::R6Class(
     "CustomCallback",
     inherit = KerasCallback,

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -223,10 +223,8 @@ test_succeeds("can get errors from generators", {
   
   model <- keras_model(list(input1, input2), out)
   
-  i <- 0
   generator <- function() {
-    i <<- i + 1
-    if (i >= 3)
+    if (runif(1) > 0.5)
       stop("generator error.")
     list(list(1, 2), 3)
   }
@@ -234,14 +232,12 @@ test_succeeds("can get errors from generators", {
   model %>% compile(loss = "mse", optimizer = "sgd")
   
   expect_error(
-    {
-      expect_warning_if(tensorflow::tf_version() >= "2.1", {
-        model %>% fit_generator(
-          generator, steps_per_epoch = 5, 
-          validation_data = list(list(1, 2), 3),
-          verbose = 0)  
-      })
-    }
+    expect_warning_if(tensorflow::tf_version() >= "2.1", {
+      model %>% fit_generator(
+        generator, steps_per_epoch = 50, 
+        validation_data = list(list(1, 2), 3),
+        verbose = 0)  
+    })
   )
   
   

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -237,7 +237,7 @@ test_succeeds("can get errors from generators", {
     {
       expect_warning_if(tensorflow::tf_version() >= "2.1", {
         model %>% fit_generator(
-          generator, steps_per_epoch = 2, 
+          generator, steps_per_epoch = 5, 
           validation_data = list(list(1, 2), 3),
           verbose = 0)  
       })

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -120,9 +120,6 @@ test_succeeds("R function can be used as custom generator", {
 
 test_succeeds("R function can be used as custom generator with multiple inputs", {
   
-  if (tensorflow::tf_version() >= "2.1")
-    skip("TODO: R based generators are not working with TF >= 2.1")
-  
   input1 <- layer_input(shape = 1)
   input2 <- layer_input(shape = 1)
   
@@ -139,14 +136,11 @@ test_succeeds("R function can be used as custom generator with multiple inputs",
   
   model %>% fit_generator(generator, steps_per_epoch = 10, 
                           validation_data = generator, validation_steps = 2,
-                          verbose = 0)
+                          verbose = 1)
 })
 
 test_succeeds("Fixed validation_data instead of generator with fit_generator", {
 
-  if (tensorflow::tf_version() >= "2.1")
-    skip("TODO: R based generators are not working with TF >= 2.1")
-  
   input1 <- layer_input(shape = 1)
   input2 <- layer_input(shape = 1)
   
@@ -169,9 +163,6 @@ test_succeeds("Fixed validation_data instead of generator with fit_generator", {
 })
 
 test_succeeds("Can use a custom preprocessing function in image_data_generator", {
-  
-  if (tensorflow::tf_version() >= "2.1")
-    skip("TODO: R based generators are not working with TF >= 2.1")
   
   img_gen <- image_data_generator(preprocessing_function = function(x) x/255)
   

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -232,14 +232,12 @@ test_succeeds("can get errors from generators", {
   model %>% compile(loss = "mse", optimizer = "sgd")
   
   expect_error(
-    expect_warning_if(tensorflow::tf_version() >= "2.1", {
-      model %>% fit_generator(
-        generator, steps_per_epoch = 50, 
-        validation_data = list(list(1, 2), 3),
-        verbose = 0)  
-    })
+    model %>% fit(
+      generator, steps_per_epoch = 50, 
+      validation_data = list(list(1, 2), 3),
+      verbose = 0),
+    regexp = "Error"
   )
-  
   
 })
 

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -70,6 +70,9 @@ test_succeeds("image data generator can be used for training", {
 
 test_succeeds("R function can be used as custom generator", {
  
+  if (tensorflow::tf_version() == "2.1")
+    skip("don't work in tf2.1")
+  
   # create model
   model <- keras_model_sequential()
   
@@ -120,6 +123,9 @@ test_succeeds("R function can be used as custom generator", {
 
 test_succeeds("R function can be used as custom generator with multiple inputs", {
   
+  if (tensorflow::tf_version() == "2.1")
+    skip("don't work in tf2.1")
+  
   input1 <- layer_input(shape = 1)
   input2 <- layer_input(shape = 1)
   
@@ -141,6 +147,9 @@ test_succeeds("R function can be used as custom generator with multiple inputs",
 
 test_succeeds("Fixed validation_data instead of generator with fit_generator", {
 
+  if (tensorflow::tf_version() == "2.1")
+    skip("don't work in tf2.1")
+  
   input1 <- layer_input(shape = 1)
   input2 <- layer_input(shape = 1)
   
@@ -163,6 +172,9 @@ test_succeeds("Fixed validation_data instead of generator with fit_generator", {
 })
 
 test_succeeds("Can use a custom preprocessing function in image_data_generator", {
+  
+  if (tensorflow::tf_version() == "2.1")
+    skip("don't work in tf2.1")
   
   img_gen <- image_data_generator(preprocessing_function = function(x) x/255)
   

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -213,31 +213,5 @@ test_succeeds("Can use a custom preprocessing function in image_data_generator",
   
 })
 
-test_succeeds("can get errors from generators", {
-  
-  input1 <- layer_input(shape = 1)
-  input2 <- layer_input(shape = 1)
-  
-  out <- layer_add(list(input1, input2)) %>% 
-    layer_dense(units = 1)
-  
-  model <- keras_model(list(input1, input2), out)
-  
-  generator <- function() {
-    if (runif(1) > 0.5)
-      stop("generator error.")
-    list(list(1, 2), 3)
-  }
-  
-  model %>% compile(loss = "mse", optimizer = "sgd")
-  
-  expect_error(
-    model %>% fit(
-      generator, steps_per_epoch = 50, 
-      validation_data = list(list(1, 2), 3),
-      verbose = 0)
-  )
-  
-})
 
 

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -235,8 +235,7 @@ test_succeeds("can get errors from generators", {
     model %>% fit(
       generator, steps_per_epoch = 50, 
       validation_data = list(list(1, 2), 3),
-      verbose = 0),
-    regexp = "Error"
+      verbose = 0)
   )
   
 })

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -213,4 +213,38 @@ test_succeeds("Can use a custom preprocessing function in image_data_generator",
   
 })
 
+test_succeeds("can get errors from generators", {
+  
+  input1 <- layer_input(shape = 1)
+  input2 <- layer_input(shape = 1)
+  
+  out <- layer_add(list(input1, input2)) %>% 
+    layer_dense(units = 1)
+  
+  model <- keras_model(list(input1, input2), out)
+  
+  i <- 0
+  generator <- function() {
+    i <<- i + 1
+    if (i >= 3)
+      stop("generator error.")
+    list(list(1, 2), 3)
+  }
+  
+  model %>% compile(loss = "mse", optimizer = "sgd")
+  
+  expect_error(
+    {
+      expect_warning_if(tensorflow::tf_version() >= "2.1", {
+        model %>% fit_generator(
+          generator, steps_per_epoch = 2, 
+          validation_data = list(list(1, 2), 3),
+          verbose = 0)  
+      })
+    }
+  )
+  
+  
+})
+
 

--- a/tests/testthat/test-generators.R
+++ b/tests/testthat/test-generators.R
@@ -70,11 +70,7 @@ test_succeeds("image data generator can be used for training", {
 
 test_succeeds("R function can be used as custom generator", {
  
-  if (tensorflow::tf_version() >= "2.1")
-    skip("TODO: R based generators are not working with TF >= 2.1")
-  
   # create model
-  library(keras)
   model <- keras_model_sequential()
   
   # add layers and compile the model
@@ -108,7 +104,7 @@ test_succeeds("R function can be used as custom generator", {
   # Train the model, iterating on the data in batches of 32 samples
   model %>% 
     fit_generator(sampling_generator(X_train, Y_train, batch_size = 32), 
-                  steps_per_epoch = 10, epochs = 2, verbose = 0)
+                  steps_per_epoch = 10, epochs = 2, verbose = 1)
   
   # Evaluate the model
   model %>% 

--- a/tests/testthat/test-preprocessing.R
+++ b/tests/testthat/test-preprocessing.R
@@ -135,7 +135,8 @@ test_succeeds("flow images from directory works", {
   if (!have_pillow())
     skip("Pillow required.")
   
-  dir <- tempdir()
+  dir <- tempfile()
+  dir.create(dir)
   dir.create(paste0(dir, "/flow-img"))
   dir <- paste0(dir, "/flow-img")
   dir.create(paste0(dir, "/0"))
@@ -165,14 +166,16 @@ test_succeeds("flow images from directory works", {
   
   model %>% compile(loss = "binary_crossentropy", optimizer = "adam")
   
-  # test fitting the model
-  model %>% fit_generator(gen, steps_per_epoch = 20)
-  
-  # test predictions
-  preds <- predict_generator(model, gen, steps = 10)
-  
-  # evaluate
-  eva <- evaluate_generator(model, gen, steps = 10)
+  expect_warning_if(tensorflow::tf_version() >= "2.1", {
+    # test fitting the model
+    model %>% fit_generator(gen, steps_per_epoch = 20)
+    
+    # test predictions
+    preds <- predict_generator(model, gen, steps = 10)
+    
+    # evaluate
+    eva <- evaluate_generator(model, gen, steps = 10)
+  })
 })
 
 test_succeeds("images_dataset_from_directory", {

--- a/tests/testthat/test-timeseries.R
+++ b/tests/testthat/test-timeseries.R
@@ -17,7 +17,8 @@ test_call_succeeds("timeseries_generator", required_version = "2.1.5", {
     loss = "binary_crossentropy",
     metrics = "accuracy"
   )
-  
-  model %>% fit_generator(data_gen, steps_per_epoch = 10, 
-                          validation_data = data_gen, validation_steps = 2)
+  expect_warning_if(tensorflow::tf_version() >= "2.1", {
+    model %>% fit_generator(data_gen, steps_per_epoch = 10, 
+                            validation_data = data_gen, validation_steps = 2)  
+  })
 })

--- a/tests/testthat/test-timeseries.R
+++ b/tests/testthat/test-timeseries.R
@@ -18,5 +18,5 @@ test_call_succeeds("timeseries_generator", required_version = "2.1.5", {
     metrics = "accuracy"
   )
   
-  model %>% fit_generator(data_gen, steps_per_epoch = 10)
+  model %>% fit_generator(data_gen, steps_per_epoch = 10, validation_data = data_gen)
 })

--- a/tests/testthat/test-timeseries.R
+++ b/tests/testthat/test-timeseries.R
@@ -18,5 +18,6 @@ test_call_succeeds("timeseries_generator", required_version = "2.1.5", {
     metrics = "accuracy"
   )
   
-  model %>% fit_generator(data_gen, steps_per_epoch = 10, validation_data = data_gen)
+  model %>% fit_generator(data_gen, steps_per_epoch = 10, 
+                          validation_data = data_gen, validation_steps = 2)
 })


### PR DESCRIPTION
This fixes the problem of calling generators from different threads. Essentially what we do is:

1. Instead of passing the R generator, we pass a dummy generator that just reads elements from a queue.
2. The queue is updated by a callback that runs the R generator before the data is actually requested by `fit`/`predict`/`evaluate`.

This works because callbacks are executed in the main thread and we no longer need to execute R code from background threads.

User might see a warning:

> WARNING:tensorflow:Callback method `on_train_batch_begin` is slow compared to the batch time (batch time: 0.0007s vs `on_train_batch_begin` time: 0.0012s). Check your callbacks.


This is expected because it's `on_train_batch_begin` that the R generator is evaluated.

Fixes #986 
Fixes #1104
