### PR TITLE
update CI, install_keras

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,6 @@ jobs:
       TF_VERSION: ${{ matrix.tf }}
       PIP_NO_WARN_SCRIPT_LOCATION: 'false'
       RETICULATE_AUTOCONFIGURE: 'FALSE'
-      RETICULATE_MINICONDA_PATH: ${{ runner.temp }}/r-miniconda
       R_COMPILE_AND_INSTALL_PACKAGES: 'never'
       OS_LABEL: ${{ matrix.os }}
 
@@ -36,9 +35,9 @@ jobs:
         run: |
           echo "RSPM=https://packagemanager.rstudio.com/all/__linux__/$(lsb_release -cs)/latest" >> $GITHUB_ENV
 
-      # - name: Configure reticulate to use runner image miniconda
-      #   run: |
-      #     echo "RETICULATE_MINICONDA_PATH=${CONDA}" >> $GITHUB_ENV
+      - name: Configure reticulate miniconda path
+        run: |
+          echo "RETICULATE_MINICONDA_PATH=${RUNNER_TEMP}/r-miniconda" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "RSPM=https://packagemanager.rstudio.com/all/__linux__/$(lsb_release -cs)/latest" >> $GITHUB_ENV
 
-      - name: Configure reticulate to use system miniconda
+      - name: Configure reticulate to use runner image miniconda
         run: |
           echo "RETICULATE_MINICONDA_PATH=${CONDA}" >> $GITHUB_ENV
 
@@ -44,12 +44,25 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           Ncpus: '2L'
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@master
 
+      - name: Get R version
+        run: |
+          writeLines(sprintf("R-%i.%i", R.version$major, R.version$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Restore R package cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ matrix.os }}-${{ hashFiles('.github/R-version') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}
+
       - name: Install remotes
         shell: Rscript {0}
-        run: install.packages("remotes")
+        run: if(!require("remotes")) install.packages("remotes")
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -58,13 +71,14 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements(Sys.getenv("OS_LABEL")))')
-          sudo apt-get install -y python3-venv
+          # sudo apt-get install -y python3-venv
 
       - name: Install dependencies
         shell: Rscript {0}
         run: |
           # remotes::install_github('rstudio/reticulate')
           # remotes::install_github('rstudio/tensorflow')
+          remotes::update_packages()
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
           remotes::install_local()
@@ -72,13 +86,13 @@ jobs:
       - name: Debug Output
         run: |
           env
-          cat ~/.Rprofile
+          Rscript -e 'Sys.getenv()'
           Rscript -e 'reticulate::py_config()'
 
       - name: Install TensorFlow
         shell: Rscript {0}
         run: |
-          # reticulate::conda_create('r-reticulate')
+          reticulate::conda_create('r-reticulate')
           keras::install_keras(tensorflow = Sys.getenv("TF_VERSION"),
                                envname = "r-reticulate")
           print(reticulate::py_config())

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,7 @@ jobs:
       TF_VERSION: ${{ matrix.tf }}
       PIP_NO_WARN_SCRIPT_LOCATION: 'false'
       RETICULATE_AUTOCONFIGURE: 'FALSE'
+      RETICULATE_MINICONDA_PATH: ${{ runner.temp }}/r-miniconda
       R_COMPILE_AND_INSTALL_PACKAGES: 'never'
       OS_LABEL: ${{ matrix.os }}
 
@@ -57,14 +58,16 @@ jobs:
 
       - name: Restore R package cache
         uses: actions/cache@v2
+        id: r-package-cache
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.os }}-${{ steps.r-version.outputs.major-minor }}
-          restore-keys: ${{ runner.os }}-${{ steps.r-version.outputs.major-minor }}
+          key: ${{ matrix.os }}--${{ steps.r-version.outputs.major-minor }}
+          restore-keys: ${{ runner.os }}--${{ steps.r-version.outputs.major-minor }}
 
       - name: Install remotes
+        if: steps.r-package-cache.outputs.cache-hit != 'true'
+        run: install.packages("remotes")
         shell: Rscript {0}
-        run: if(!require("remotes")) install.packages("remotes")
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -85,7 +88,16 @@ jobs:
           remotes::install_cran("rcmdcheck")
           remotes::install_local()
 
+      - name: Restore r-miniconda
+        uses: actions/cache@v2
+        id: r-miniconda-cache
+        with:
+          path: ${{ env.RETICULATE_MINICONDA_PATH }}
+          key: ${{ matrix.os }}--${{ steps.r-version.outputs.major-minor }}--tf-${{ matrix.tf }}
+          restore-keys: ${{ runner.os }}--${{ steps.r-version.outputs.major-minor }}--tf-${{ matrix.tf }}
+
       - name: Install Miniconda
+        if: steps.r-miniconda-cache.outputs.cache-hit != 'true'
         run: reticulate::install_miniconda()
         shell: Rscript {0}
 
@@ -96,11 +108,11 @@ jobs:
           Rscript -e 'reticulate::py_config()'
 
       - name: Install TensorFlow
+        if: steps.r-miniconda-cache.outputs.cache-hit != 'true'
         shell: Rscript {0}
         run: |
-          reticulate::conda_create('r-reticulate')
-          keras::install_keras(tensorflow = Sys.getenv("TF_VERSION"),
-                               envname = "r-reticulate")
+          # reticulate::conda_create('r-reticulate')
+          keras::install_keras(tensorflow = Sys.getenv("TF_VERSION"))
           print(reticulate::py_config())
 
       - name: Check

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,6 +36,7 @@ jobs:
           echo "RSPM=https://packagemanager.rstudio.com/all/__linux__/$(lsb_release -cs)/latest" >> $GITHUB_ENV
 
       - name: Configure reticulate miniconda path
+        shell: bash
         run: |
           echo "RETICULATE_MINICONDA_PATH=${RUNNER_TEMP}/r-miniconda" >> $GITHUB_ENV
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,7 +78,7 @@ jobs:
           done < <(Rscript -e 'writeLines(remotes::system_requirements(Sys.getenv("OS_LABEL")))')
           # sudo apt-get install -y python3-venv
 
-      - name: Install dependencies
+      - name: Install R package dependencies
         shell: Rscript {0}
         run: |
           # remotes::install_github('rstudio/reticulate')
@@ -100,12 +100,6 @@ jobs:
         if: steps.r-miniconda-cache.outputs.cache-hit != 'true'
         run: reticulate::install_miniconda()
         shell: Rscript {0}
-
-      - name: Debug Output
-        run: |
-          env
-          Rscript -e 'Sys.getenv()'
-          Rscript -e 'reticulate::py_config()'
 
       - name: Install TensorFlow
         if: steps.r-miniconda-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-20.04', 'windows-latest', 'macOS-latest']
-        tf: ['2.5']
+        tf: ['2.2', '2.3', '2.4', '2.5', 'nightly']
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} (TF ${{ matrix.tf }})

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-18.04']
-        tf: ['2.5.0'] # '2.1.4', '2.2.3', '2.3.3', '2.4.2', , 'nightly'
+        tf: ['2.5.0']
         include:
           - os: ubuntu-18.04
             rspm: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-18.04']
-        tf: ['2.1.4', '2.2.3', '2.3.3', '2.4.2', '2.5.0', 'nightly']
+        tf: ['2.5.0'] # '2.1.4', '2.2.3', '2.3.3', '2.4.2', , 'nightly'
         include:
           - os: ubuntu-18.04
-            cran: https://demo.rstudiopm.com/all/__linux__/bionic/latest
+            rspm: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
           - tf: nightly
             allow_failure: true
     runs-on: ${{ matrix.os }}
@@ -27,34 +27,62 @@ jobs:
       TF_VERSION: ${{ matrix.tf }}
       PIP_NO_WARN_SCRIPT_LOCATION: false
       RETICULATE_AUTOCONFIGURE: 'FALSE'
-      CRAN: ${{ matrix.cran }}
+      R_COMPILE_AND_INSTALL_PACKAGES: never
+      RSPM: ${{ matrix.rspm }}
 
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@master
       - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        shell: Rscript
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+
+      - name: Restore R package cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
         run: |
-          Rscript -e "install.packages('remotes')" -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo -s eval "$sysreqs"
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "18.04"))')
+
       - name: Install dependencies
-        run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
+        shell: Rscript
+        run: |
+          remotes::install_github('rstudio/reticulate')
+          remotes::install_github('rstudio/tensorflow')
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+
       - name: Install Miniconda
-        run: |
-          Rscript -e "remotes::install_github('rstudio/reticulate')"
-          Rscript -e "reticulate::install_miniconda()"
-      - if: runner.os == 'macOS'
-        run: echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
+        shell: Rscript
+        run: reticulate::install_miniconda()
+
       - name: Install TensorFlow
+        shell: Rscript
         run: |
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = c('python==3.7', 'numpy==1.19'))"
-          Rscript -e "remotes::install_local()"
-          Rscript -e "keras::install_keras(tensorflow = Sys.getenv('TF_VERSION'), extra_packages = c('IPython', 'requests', 'certifi', 'urllib3'))"
-          Rscript -e "reticulate::py_install('Pillow<8.3.0')"
+          remotes::install_local()
+          keras::install_keras()
+
       - name: Check
         continue-on-error: ${{ contains(matrix.allow_failure, 'true') }}
-        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--no-manual', error_on = 'warning', check_dir = 'check')"
+        run: |
+          options(crayon.enabled = TRUE)
+          rcmdcheck::rcmdcheck(args = '--no-manual', error_on = 'warning', check_dir = 'check')
+        shell: Rscript
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,9 +35,9 @@ jobs:
         run: |
           echo "RSPM=https://packagemanager.rstudio.com/all/__linux__/$(lsb_release -cs)/latest" >> $GITHUB_ENV
 
-      - name: Configure reticulate to use runner image miniconda
-        run: |
-          echo "RETICULATE_MINICONDA_PATH=${CONDA}" >> $GITHUB_ENV
+      # - name: Configure reticulate to use runner image miniconda
+      #   run: |
+      #     echo "RETICULATE_MINICONDA_PATH=${CONDA}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
 
@@ -49,16 +49,18 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@master
 
       - name: Get R version
+        id: r-version
         run: |
-          writeLines(sprintf("R-%s.%s", R.version$major, R.version$minor), ".github/R-version")
+          writeLines(sprintf(
+            "::set-output name=major-minor::R-%s.%s", R.version$major, R.version$minor))
         shell: Rscript {0}
 
       - name: Restore R package cache
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.os }}-${{ hashFiles('.github/R-version') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}
+          key: ${{ matrix.os }}-${{ steps.r-version.outputs.major-minor }}
+          restore-keys: ${{ runner.os }}-${{ steps.r-version.outputs.major-minor }}
 
       - name: Install remotes
         shell: Rscript {0}
@@ -82,6 +84,10 @@ jobs:
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
           remotes::install_local()
+
+      - name: Install Miniconda
+        run: reticulate::install_miniconda()
+        shell: Rscript {0}
 
       - name: Debug Output
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Get R version
         run: |
-          writeLines(sprintf("R-%i.%i", R.version$major, R.version$minor), ".github/R-version")
+          writeLines(sprintf("R-%s.%s", R.version$major, R.version$minor), ".github/R-version")
         shell: Rscript {0}
 
       - name: Restore R package cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,13 +27,17 @@ jobs:
       RETICULATE_AUTOCONFIGURE: 'FALSE'
       R_COMPILE_AND_INSTALL_PACKAGES: 'never'
       OS_LABEL: ${{ matrix.os }}
-      RETICULATE_MINICONDA_PATH: ${{ env.CONDA }}
+
 
     steps:
       - name: Configure RSPM
         if: runner.os == 'Linux' # startsWith(matrix.os, 'ubuntu')
         run: |
           echo "RSPM=https://packagemanager.rstudio.com/all/__linux__/$(lsb_release -cs)/latest" >> $GITHUB_ENV
+
+      - name: Configure reticulate to use system miniconda
+        run: |
+          echo "RETICULATE_MINICONDA_PATH=${CONDA}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,46 +8,44 @@ on:
 
 name: R-CMD-check
 
+
 jobs:
   R-CMD-check:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'macOS-latest', 'ubuntu-18.04']
-        tf: ['2.5.0']
-        include:
-          - os: ubuntu-18.04
-            rspm: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-          - tf: nightly
-            allow_failure: true
+        os: ['ubuntu-20.04', 'windows-latest', 'macOS-latest']
+        tf: ['2.5']
+
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} (TF ${{ matrix.tf }})
+    continue-on-error: ${{ matrix.tf == 'nightly' }}
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: 'true'
       TF_VERSION: ${{ matrix.tf }}
-      PIP_NO_WARN_SCRIPT_LOCATION: false
+      PIP_NO_WARN_SCRIPT_LOCATION: 'false'
       RETICULATE_AUTOCONFIGURE: 'FALSE'
-      R_COMPILE_AND_INSTALL_PACKAGES: never
-      RSPM: ${{ matrix.rspm }}
+      R_COMPILE_AND_INSTALL_PACKAGES: 'never'
+      OS_LABEL: ${{ matrix.os }}
+      RETICULATE_MINICONDA_PATH: ${{ env.CONDA }}
 
     steps:
+      - name: Configure RSPM
+        if: runner.os == 'Linux' # startsWith(matrix.os, 'ubuntu')
+        run: |
+          echo "RSPM=https://packagemanager.rstudio.com/all/__linux__/$(lsb_release -cs)/latest" >> $GITHUB_ENV
+
       - uses: actions/checkout@v2
+
       - uses: r-lib/actions/setup-r@master
+        with:
+          Ncpus: '2L'
+
       - uses: r-lib/actions/setup-pandoc@master
 
-      - name: Query dependencies
-        shell: Rscript
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Install remotes
+        shell: Rscript {0}
+        run: install.packages("remotes")
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -55,32 +53,36 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "18.04"))')
+          done < <(Rscript -e 'writeLines(remotes::system_requirements(Sys.getenv("OS_LABEL")))')
+          sudo apt-get install -y python3-venv
 
       - name: Install dependencies
-        shell: Rscript
+        shell: Rscript {0}
         run: |
-          remotes::install_github('rstudio/reticulate')
-          remotes::install_github('rstudio/tensorflow')
+          # remotes::install_github('rstudio/reticulate')
+          # remotes::install_github('rstudio/tensorflow')
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
+          remotes::install_local()
 
-      - name: Install Miniconda
-        shell: Rscript
-        run: reticulate::install_miniconda()
+      - name: Debug Output
+        run: |
+          env
+          cat ~/.Rprofile
+          Rscript -e 'reticulate::py_config()'
 
       - name: Install TensorFlow
-        shell: Rscript
+        shell: Rscript {0}
         run: |
-          remotes::install_local()
-          keras::install_keras()
+          # reticulate::conda_create('r-reticulate')
+          keras::install_keras(tensorflow = Sys.getenv("TF_VERSION"),
+                               envname = "r-reticulate")
+          print(reticulate::py_config())
 
       - name: Check
-        continue-on-error: ${{ contains(matrix.allow_failure, 'true') }}
+        shell: Rscript {0}
         run: |
-          options(crayon.enabled = TRUE)
           rcmdcheck::rcmdcheck(args = '--no-manual', error_on = 'warning', check_dir = 'check')
-        shell: Rscript
 
       - name: Show testthat output
         if: always()

--- a/R/install.R
+++ b/R/install.R
@@ -106,7 +106,7 @@ install_keras <- function(method = c("auto", "virtualenv", "conda"),
                           conda = "auto",
                           version = "default",
                           tensorflow = "default",
-                          extra_packages = c("tensorflow-hub", "requests", "Pillow~=8.2", "pyyaml"),
+                          extra_packages = c("tensorflow-hub", "scipy", "requests", "Pillow~=8.2", "pyyaml"),
                           ...) {
 
   # verify method

--- a/R/install.R
+++ b/R/install.R
@@ -106,7 +106,7 @@ install_keras <- function(method = c("auto", "virtualenv", "conda"),
                           conda = "auto",
                           version = "default",
                           tensorflow = "default",
-                          extra_packages = c("tensorflow-hub"),
+                          extra_packages = c("tensorflow-hub", "requests", "Pillow~=8.2", "pyyaml"),
                           ...) {
 
   # verify method
@@ -124,14 +124,14 @@ install_keras <- function(method = c("auto", "virtualenv", "conda"),
     # conda is the only supported method on windows
     method <- "conda"
 
-    # confirm we actually have conda
-    have_conda <- !is.null(tryCatch(conda_binary(conda), error = function(e) NULL))
-    if (!have_conda) {
-      stop("Keras installation failed (no conda binary found)\n\n",
-           "Install Anaconda for Python 3.x (https://www.anaconda.com/download/#windows)\n",
-           "before installing Keras.",
-           call. = FALSE)
-    }
+    # confirm we actually have conda - let reticulate prompt miniconda installation
+    # have_conda <- !is.null(tryCatch(conda_binary(conda), error = function(e) NULL))
+    # if (!have_conda) {
+    #   stop("Keras installation failed (no conda binary found)\n\n",
+    #        "Install Anaconda for Python 3.x (https://www.anaconda.com/download/#windows)\n",
+    #        "before installing Keras.",
+    #        call. = FALSE)
+    # }
 
     # avoid DLL in use errors
     if (py_available()) {
@@ -141,31 +141,9 @@ install_keras <- function(method = c("auto", "virtualenv", "conda"),
     }
   }
 
-  extra_packages <- unique(c(
-    paste0("keras", version),
-    extra_packages,
-
-    "requests",
-    "Pillow"
-  ))
-
-  if (tensorflow == "default" || tensorflow == "nightly" ||
-      package_version(tensorflow) >= "2.4")
-  {
-    # can install the mre recent versions recently
-    extra_packages <- c(
-      extra_packages,
-      "h5py",
-      "pyyaml"
-    )
-  } else {
-    # we need fixed versions of hdf5 to work with older versions of
-    # tensorflow
-    extra_packages <- c(
-      extra_packages,
-      "h5py==2.10.0",
-      "pyyaml==3.12"
-    )
+  if(is.na(Sys.getenv("RETICULATE_MINICONDA_PYTHON_VERSION"))) {
+    Sys.setenv("RETICULATE_MINICONDA_PYTHON_VERSION" = "3.7")
+    on.exit(Sys.unsetenv("RETICULATE_MINICONDA_PYTHON_VERSION"))
   }
 
   # perform the install

--- a/man/install_keras.Rd
+++ b/man/install_keras.Rd
@@ -9,7 +9,7 @@ install_keras(
   conda = "auto",
   version = "default",
   tensorflow = "default",
-  extra_packages = c("tensorflow-hub", "requests", "Pillow~=8.2", "pyyaml"),
+  extra_packages = c("tensorflow-hub", "scipy", "requests", "Pillow~=8.2", "pyyaml"),
   ...
 )
 }

--- a/man/install_keras.Rd
+++ b/man/install_keras.Rd
@@ -9,7 +9,7 @@ install_keras(
   conda = "auto",
   version = "default",
   tensorflow = "default",
-  extra_packages = c("tensorflow-hub"),
+  extra_packages = c("tensorflow-hub", "requests", "Pillow~=8.2", "pyyaml"),
   ...
 )
 }

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -14,7 +14,8 @@ expect_warning_if <- function(cond, expr) {
   )
 }
 
-py_capture_output <- reticulate::import("IPython")$utils$capture$capture_output
+py_capture_output <- reticulate::py_capture_output #import("IPython")$utils$capture$capture_output
+
 
 test_succeeds <- function(desc, expr, required_version = NULL) {
 

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -23,7 +23,7 @@ test_succeeds <- function(desc, expr, required_version = NULL) {
     capture.output({
       test_that(desc, {
         skip_if_no_keras(required_version)
-        with(py_capture_output(), {
+        py_capture_output({
           expect_error(force(expr), NA)
         })
       })


### PR DESCRIPTION
- refactor so CI calls 'install_keras()' with no arguments
- use actions/cache@v2
- use remotes::system_requirements() instead of sysreq/r-hub
- set R_COMPILE_AND_INSTALL_PACKAGES=never
- update RSPM rstudio package manager url
- print testthat output by default
- default to use python 3.7 for the conda base if not conda exists
- don't use platform specific .Rprofile hints
- use reticulate and tensorflow R packages from github/master