### PR TITLE
Model.fit_generator is deprecated and Use 1-based for returned values

### DIFF
--- a/R/backend.R
+++ b/R/backend.R
@@ -120,7 +120,7 @@ k_argmax <- function(x, axis = -1) {
   keras$backend$argmax(
     x = x,
     axis = as_axis(axis)
-  )
+  ) + 1L # Use 1-based for returned value
 }
 
 
@@ -139,7 +139,7 @@ k_argmin <- function(x, axis = -1) {
   keras$backend$argmin(
     x = x,
     axis = as_axis(axis)
-  )
+  ) + 1L # Use 1-based for returned value
 }
 
 

--- a/vignettes/applications.Rmd
+++ b/vignettes/applications.Rmd
@@ -131,7 +131,7 @@ freeze_weights(base_model)
 model %>% compile(optimizer = 'rmsprop', loss = 'categorical_crossentropy')
 
 # train the model on the new data for a few epochs
-model %>% fit_generator(...)
+model %>% fit(...)
 
 # at this point, the top layers are well trained and we can start fine-tuning
 # convolutional layers from inception V3. We will freeze the bottom N layers
@@ -157,7 +157,7 @@ model %>% compile(
 
 # we train our model again (this time fine-tuning the top 2 inception blocks
 # alongside the top Dense layers
-model %>% fit_generator(...)
+model %>% fit(...)
 ```
 
 


### PR DESCRIPTION
[Model.fit which supports generators](https://github.com/keras-team/keras/blob/d8fcb9d4d4dad45080ecfdd575483653028f8eda/keras/engine/training.py#L2204)