### PR TITLE
adjust reticulate class filter for keras3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # keras (development version)
 
+- Updates to allow both R packages {keras} and {keras3} to be loaded. 
+
 # keras 2.13.0
 
 - Default TF version installed by `install_keras()` is now 2.13.

--- a/R/package.R
+++ b/R/package.R
@@ -153,7 +153,23 @@ keras <- NULL
     classes <- sub(paste0("^", module), "keras", classes)
 
     # All python symbols moved in v2.13 under .src
-    classes <- sub("^keras\\.src\\.", "keras.", classes)
+    # Preserve the original symbols for compatability with keras3,
+    # interleaving the back-compat class names after the originals.
+    # E.g., this:
+    # "keras.src.models.sequential.Sequential"
+    # "keras.src.models.model.Model"
+    # ... "python.builtin.object"
+    #
+    # becomes this:
+    # "keras.src.models.sequential.Sequential" "keras.models.sequential.Sequential"
+    # "keras.src.models.model.Model" "keras.models.model.Model"
+    # ... "python.builtin.object"
+
+    classes <- unique(as.vector(rbind(
+      classes,
+      sub("^keras\\.src\\.", "keras.", classes),
+      deparse.level = 0
+    )))
 
     # let KerasTensor inherit all the S3 methods of tf.Tensor, but
     # KerasTensor methods take precedence.


### PR DESCRIPTION
This PR permits both packages `{keras}` and `{keras3}` to be loaded in the same R session. 

Note, generally, there is no need to use both packages, and users should prefer using "keras3". This is only to allow for everything to still function properly if both are loaded.