### PR TITLE
Updating documentation of install_keras for argument backend: changing "pytorch" to "torch" so that installs with backend PyTorch do not fail

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -5,10 +5,10 @@
 #' @param envname Name of or path to a Python virtual environment
 #' @param extra_packages Additional Python packages to install alongside Keras
 #' @param python_version Passed on to `reticulate::virtualenv_starter()`
-#' @param backend Which backend(s) to install. Accepted values include `"tensorflow"`, `"jax"` and `"pytorch"`
+#' @param backend Which backend(s) to install. Accepted values include `"tensorflow"`, `"jax"` and `"torch"`
 #' @param gpu whether to install a GPU capable version of the backend.
 #' @param restart_session Whether to restart the R session after installing (note this will only occur within RStudio).
-#' @param ... reserved for future compatability.
+#' @param ... reserved for future compatibility.
 #'
 #' @returns No return value, called for side effects.
 #'
@@ -19,7 +19,7 @@ install_keras <- function(
     extra_packages = c("scipy", "pandas", "Pillow", "pydot", "ipython", "tensorflow_datasets"),
     python_version = ">=3.9,<=3.11",
     # backend = "tensorflow",
-    backend = c("tensorflow", "jax"),
+    backend = c("tensorflow", "jax", "torch"),
     # backend = "tf-nightly",
     gpu = NA,
     restart_session = TRUE) {

--- a/R/install.R
+++ b/R/install.R
@@ -19,7 +19,7 @@ install_keras <- function(
     extra_packages = c("scipy", "pandas", "Pillow", "pydot", "ipython", "tensorflow_datasets"),
     python_version = ">=3.9,<=3.11",
     # backend = "tensorflow",
-    backend = c("tensorflow", "jax", "torch"),
+    backend = c("tensorflow", "jax"),
     # backend = "tf-nightly",
     gpu = NA,
     restart_session = TRUE) {

--- a/man/install_keras.Rd
+++ b/man/install_keras.Rd
@@ -10,7 +10,7 @@ install_keras(
   extra_packages = c("scipy", "pandas", "Pillow", "pydot", "ipython",
     "tensorflow_datasets"),
   python_version = ">=3.9,<=3.11",
-  backend = c("tensorflow", "jax"),
+  backend = c("tensorflow", "jax", "torch"),
   gpu = NA,
   restart_session = TRUE
 )
@@ -18,13 +18,13 @@ install_keras(
 \arguments{
 \item{envname}{Name of or path to a Python virtual environment}
 
-\item{...}{reserved for future compatability.}
+\item{...}{reserved for future compatibility.}
 
 \item{extra_packages}{Additional Python packages to install alongside Keras}
 
 \item{python_version}{Passed on to \code{reticulate::virtualenv_starter()}}
 
-\item{backend}{Which backend(s) to install. Accepted values include \code{"tensorflow"}, \code{"jax"} and \code{"pytorch"}}
+\item{backend}{Which backend(s) to install. Accepted values include \code{"tensorflow"}, \code{"jax"} and \code{"torch"}}
 
 \item{gpu}{whether to install a GPU capable version of the backend.}
 

--- a/man/install_keras.Rd
+++ b/man/install_keras.Rd
@@ -10,7 +10,7 @@ install_keras(
   extra_packages = c("scipy", "pandas", "Pillow", "pydot", "ipython",
     "tensorflow_datasets"),
   python_version = ">=3.9,<=3.11",
-  backend = c("tensorflow", "jax", "torch"),
+  backend = c("tensorflow", "jax"),
   gpu = NA,
   restart_session = TRUE
 )


### PR DESCRIPTION
At the moment,  `?keras3::install_keras` directs the user to set argument `backend = "pytorch"` if *PyTorch* should be used as backend. 

However, calling `keras3::install_keras(backend = "pytorch")` results in the following error when the install script tries to install python library `pytorch` instead of `torch`.

```R
Building wheels for collected packages: pytorch
  Building wheel for pytorch (setup.py): started
  Building wheel for pytorch (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-txzdxwsv/pytorch_a6fa11d41d8a42f69116e4f171a6990a/setup.py", line 15, in <module>
          raise Exception(message)
      Exception: You tried to install "pytorch". The package named for PyTorch is "torch"
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pytorch
```

On the other hand, if `keras3::install_keras(backend = "torch")` is called, the installation finishes as expected. 

This PR changes the documentation accordingly and adds `torch` to the backend argument vector (as e.g. in `?keras3::use_backend`.
