### PR TITLE
Fix CRAN NOTE on R-devel (4.6)

### DIFF
--- a/vignettes-src/training_with_built_in_methods.Rmd
+++ b/vignettes-src/training_with_built_in_methods.Rmd
@@ -1085,7 +1085,7 @@ A callback has access to its associated model through the
 class property `self$model`.
 
 Make sure to read the
-[complete guide to writing custom callbacks](../writing_your_own_callbacks.html).
+[complete guide to writing custom callbacks](https://keras3.posit.co/articles/writing_your_own_callbacks.html).
 
 Here's a simple example saving a list of per-batch loss values during training:
 

--- a/vignettes/training_with_built_in_methods.Rmd
+++ b/vignettes/training_with_built_in_methods.Rmd
@@ -1305,7 +1305,7 @@ A callback has access to its associated model through the
 class property `self$model`.
 
 Make sure to read the
-[complete guide to writing custom callbacks](../writing_your_own_callbacks.html).
+[complete guide to writing custom callbacks](https://keras3.posit.co/articles/writing_your_own_callbacks.html).
 
 Here's a simple example saving a list of per-batch loss values during training:
 


### PR DESCRIPTION
Check Details

Version: 1.5.0
Check: relative paths in package URLs
Result: NOTE
  Found the following (possibly) invalid URL:
    URL: ../writing_your_own_callbacks.html
      From: inst/doc/training_with_built_in_methods.html
Flavors: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc