### PR TITLE
Stop overriding JAX GPU memory preallocation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # keras3 (development version)
 
+- On Linux, `use_backend("jax", gpu = TRUE)` no longer overrides
+  `XLA_PYTHON_CLIENT_MEM_FRACTION`, preserving the JAX default or a
+  user-provided value.
+
 # keras3 1.5.1
 
 - `use_backend("jax")` on macOS now defaults to `gpu = FALSE`, so `jax-metal`

--- a/R/install.R
+++ b/R/install.R
@@ -245,7 +245,6 @@ use_backend <- function(backend, gpu = NA) {
         gpu <- has_gpu()
 
       if (gpu) {
-        Sys.setenv("XLA_PYTHON_CLIENT_MEM_FRACTION" = "1.00")
         py_require(c("jax[cuda12]!=0.6.1"))
       } else {
         py_require(c("jax[cpu]"))


### PR DESCRIPTION
## Summary

Stop setting `XLA_PYTHON_CLIENT_MEM_FRACTION=1.00` when selecting the JAX GPU backend on Linux. This preserves either JAX's default allocation policy or a user-provided value.

Setting the fraction to 100% can produce a `RESOURCE_EXHAUSTED` message during CUDA initialization, even when JAX can recover and complete the operation.

## Impact

Public-facing: `use_backend("jax", gpu = TRUE)` no longer overrides the JAX GPU memory allocation configuration.

Internal: no API or Python dependency changes.

Closes #1538
