### PR TITLE
Declare TensorBoard as a Python dependency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # keras3 (development version)
 
+- TensorBoard is now declared explicitly as a Python dependency, restoring
+  `callback_tensorboard()` with TensorFlow 2.21.
+
 - On Linux, `use_backend("jax", gpu = TRUE)` no longer overrides
   `XLA_PYTHON_CLIENT_MEM_FRACTION`, preserving the JAX default or a
   user-provided value.

--- a/R/package.R
+++ b/R/package.R
@@ -70,7 +70,7 @@ keras <- NULL
     Sys.setenv(RETICULATE_PYTHON = keras_python)
 
   py_require(c(
-    "keras", "pydot", "scipy", "pandas", "Pillow", "ipython"
+    "keras", "tensorboard", "pydot", "scipy", "pandas", "Pillow", "ipython"
     #, "tensorflow_datasets"
   ))
 


### PR DESCRIPTION
## Summary

TensorFlow 2.21 no longer installs TensorBoard transitively, so `callback_tensorboard()` fails in newly resolved managed Python environments.

- Declare `tensorboard` explicitly in keras3's Python requirements.
- Restore `callback_tensorboard()` without requiring manual package installation.
- Document the user-facing change in `NEWS.md`.

This changes the managed Python dependency set. It does not change the R API or other internal behavior.

## Validation

- Fit a model with `callback_tensorboard()` in a fresh R session using TensorFlow 2.21.0 and TensorBoard 2.21.0.
